### PR TITLE
[X-09] Repository abstraction + DI conventions

### DIFF
--- a/app/CLAUDE.md
+++ b/app/CLAUDE.md
@@ -209,10 +209,126 @@ Almost all providers go with `autoDispose` to avoid leaking listeners. The excep
 - **Validated MVP microcopy** lives in `docs/06-identidad-y-tono.md` §5. Use those exact strings when implementing the corresponding screen.
 - **Don't promise false privacy.** If something will be seen by the group, say it clearly.
 
+## Dependencias y override pattern
+
+### When to declare a repository as an interface
+
+Every data-layer repository has **two files**:
+
+```
+app/lib/data/repositories/
+├── <plural>_repository.dart              ← abstract class (the contract)
+└── firestore_<plural>_repository.dart    ← Firestore impl + Riverpod provider
+```
+
+The abstract class is the public surface. Notifiers, widgets, and tests depend on
+it. The `Firestore*` implementation is the only file that imports `cloud_firestore`.
+
+Rule: **if the feature talks to Firestore, there must be an abstract repo for it**.
+Non-data abstractions (router, theme, auth state) are NOT abstracted this way.
+
+### Provider always returns the abstract type
+
+```dart
+// In firestore_trip_repository.dart
+final tripRepositoryProvider = Provider<TripRepository>((ref) {
+  return FirestoreTripRepository(ref.watch(firestoreProvider));
+});
+```
+
+Consumers never reference `FirestoreTripRepository`. They only import
+`trip_repository.dart` (the abstract type) and `firestore_trip_repository.dart`
+(for the provider symbol).
+
+### How to override in tests
+
+```dart
+// In your test file:
+final mock = MockTripRepository()..setTrips([trip1, trip2]);
+
+await tester.pumpWidget(
+  ProviderScope(
+    overrides: [
+      tripRepositoryProvider.overrideWithValue(mock),
+      currentUserIdProvider.overrideWithValue('user_test'),
+    ],
+    child: MaterialApp.router(routerConfig: _testRouter),
+  ),
+);
+```
+
+No Firebase needed. No `fake_cloud_firestore` needed for simple tests.
+Mock lives in `test/data/mocks/mock_<plural>_repository.dart`.
+
+### How to override in dev mode (main_dev.dart)
+
+```dart
+// lib/main_dev.dart — run with: flutter run -t lib/main_dev.dart
+runApp(
+  ProviderScope(
+    overrides: [
+      currentUserIdProvider.overrideWithValue('user_dev'),
+      tripRepositoryProvider.overrideWithValue(
+        MockTripRepository()..setTrips(TripFixtures.sortedSet()),
+      ),
+    ],
+    child: const VamosApp(),
+  ),
+);
+```
+
+Imports the mock from `test/data/mocks/` — that's intentional. The mock is
+test infrastructure shared between unit tests and the dev entry point.
+
+### Hypothetical backend migration (Supabase, etc.)
+
+If the backend changes, the only file that changes is the Firestore impl
+and the provider line:
+
+```dart
+// Before:
+final tripRepositoryProvider = Provider<TripRepository>((ref) {
+  return FirestoreTripRepository(ref.watch(firestoreProvider));
+});
+
+// After migrating to Supabase:
+final tripRepositoryProvider = Provider<TripRepository>((ref) {
+  return SupabaseTripRepository(ref.watch(supabaseProvider));
+});
+```
+
+Zero changes in notifiers, screens, or tests. That's the point.
+
+### Platform variant (web vs mobile) — when needed
+
+If a future web variant needs a different impl, add a branch in the provider:
+
+```dart
+final tripRepositoryProvider = Provider<TripRepository>((ref) {
+  if (kIsWeb) return WebTripRepository(ref.watch(httpClientProvider));
+  return FirestoreTripRepository(ref.watch(firestoreProvider));
+});
+```
+
+Don't anticipate this. Add it when it's actually needed.
+
+### currentUserIdProvider
+
+A simple overrideable provider for the authenticated user ID:
+
+```dart
+// Default: empty string (unauthenticated). Override in tests and dev.
+final currentUserIdProvider = Provider<String>((ref) => '');
+```
+
+TODO(E0-06): replace the default with the real auth provider once Firebase
+Auth is wired: `ref.watch(authStateProvider).value?.uid ?? ''`.
+
 ## Tests
 
 - **What's tested:** pure logic in `domain/`. Especially balance calculation and transfer simplification — that's where the painful bugs live.
-- **What's NOT tested in MVP:** widgets, screens, integration. Low ROI for Case 0.
+- **Widget tests with override:** use `ProviderScope(overrides: [...])` + `MockXxxRepository`. See `test/features/trips/presentation/my_trips_screen_test.dart` as reference.
+- **What's NOT tested in MVP:** integration, golden, or screenshot tests. Low ROI for Case 0.
 - **Mirror structure in `test/`:** `test/features/expenses/domain/balance_calculator_test.dart`.
 - **Test names and inline comments are written in English.**
 

--- a/app/lib/data/models/expense.dart
+++ b/app/lib/data/models/expense.dart
@@ -1,0 +1,113 @@
+/// Mirrors the `trips/{tripId}/expenses/{expenseId}` Firestore document.
+///
+/// See `docs/05-modelo-datos-2.md` §2.2 for the canonical schema.
+/// The [id] is the Firestore document ID and is NOT stored inside the document.
+class Expense {
+  const Expense({
+    required this.id,
+    required this.amount,
+    required this.currency,
+    required this.exchangeRate,
+    required this.amountInMainCurrency,
+    required this.paidBy,
+    required this.splitBetween,
+    required this.splitType,
+    required this.date,
+    required this.createdAt,
+    required this.createdBy,
+    required this.hasSettlements,
+    required this.editHistory,
+    this.description,
+    this.photoURL,
+    this.splitDetails,
+  });
+
+  final String id;
+
+  /// Amount in the original [currency].
+  final double amount;
+
+  /// ISO 4217, e.g. "BRL".
+  final String currency;
+
+  /// Exchange rate to the trip's mainCurrency. 1.0 if currency == mainCurrency.
+  final double exchangeRate;
+
+  /// Denormalized: amount * exchangeRate. Computed at write time.
+  final double amountInMainCurrency;
+
+  final String? description;
+  final String? photoURL;
+
+  /// userId of who paid.
+  final String paidBy;
+
+  /// userIds included in the split.
+  final List<String> splitBetween;
+
+  /// "equal" | "percentage" | "amount"
+  final String splitType;
+
+  /// Only populated when splitType != "equal".
+  final Map<String, dynamic>? splitDetails;
+
+  /// Day of the expense (may differ from [createdAt]).
+  final DateTime date;
+
+  final DateTime createdAt;
+  final String createdBy;
+
+  /// When true, edits are blocked (a settlement references this expense).
+  final bool hasSettlements;
+
+  /// Audit trail of edits. Each entry records who changed what and the old values.
+  final List<Map<String, dynamic>> editHistory;
+
+  Expense copyWith({
+    String? id,
+    double? amount,
+    String? currency,
+    double? exchangeRate,
+    double? amountInMainCurrency,
+    String? description,
+    String? photoURL,
+    String? paidBy,
+    List<String>? splitBetween,
+    String? splitType,
+    Map<String, dynamic>? splitDetails,
+    DateTime? date,
+    DateTime? createdAt,
+    String? createdBy,
+    bool? hasSettlements,
+    List<Map<String, dynamic>>? editHistory,
+  }) {
+    return Expense(
+      id: id ?? this.id,
+      amount: amount ?? this.amount,
+      currency: currency ?? this.currency,
+      exchangeRate: exchangeRate ?? this.exchangeRate,
+      amountInMainCurrency: amountInMainCurrency ?? this.amountInMainCurrency,
+      description: description ?? this.description,
+      photoURL: photoURL ?? this.photoURL,
+      paidBy: paidBy ?? this.paidBy,
+      splitBetween: splitBetween ?? this.splitBetween,
+      splitType: splitType ?? this.splitType,
+      splitDetails: splitDetails ?? this.splitDetails,
+      date: date ?? this.date,
+      createdAt: createdAt ?? this.createdAt,
+      createdBy: createdBy ?? this.createdBy,
+      hasSettlements: hasSettlements ?? this.hasSettlements,
+      editHistory: editHistory ?? this.editHistory,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Expense &&
+          runtimeType == other.runtimeType &&
+          id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
+}

--- a/app/lib/data/models/itinerary_item.dart
+++ b/app/lib/data/models/itinerary_item.dart
@@ -1,0 +1,103 @@
+/// Mirrors the `trips/{tripId}/items/{itemId}` Firestore document.
+///
+/// See `docs/05-modelo-datos-2.md` §2.2 for the canonical schema.
+/// The [id] is the Firestore document ID and is NOT stored inside the document.
+class ItineraryItem {
+  const ItineraryItem({
+    required this.id,
+    required this.title,
+    required this.day,
+    required this.authorId,
+    required this.status,
+    required this.votes,
+    required this.createdAt,
+    required this.updatedAt,
+    this.time,
+    this.location,
+    this.notes,
+    this.estimatedCostPerPerson,
+    this.estimatedCostCurrency,
+    this.estimatedCostExchangeRate,
+  });
+
+  final String id;
+  final String title;
+
+  /// Day assigned to this item (date-only; time stored separately in [time]).
+  final DateTime day;
+
+  /// Optional time string, e.g. "20:00".
+  final String? time;
+
+  /// Free-text location (no geocoding in MVP).
+  final String? location;
+
+  final String? notes;
+  final String authorId;
+
+  /// "proposed" | "confirmed"
+  final String status;
+
+  /// Vote map: { userId: "yes" | "no" }.
+  /// Counts are computed on the client from this map.
+  final Map<String, String> votes;
+
+  /// Optional estimated cost per person in [estimatedCostCurrency].
+  final double? estimatedCostPerPerson;
+
+  /// ISO 4217 currency for the estimated cost.
+  final String? estimatedCostCurrency;
+
+  /// Exchange rate to the trip's mainCurrency. 1.0 if same currency.
+  final double? estimatedCostExchangeRate;
+
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  ItineraryItem copyWith({
+    String? id,
+    String? title,
+    DateTime? day,
+    String? time,
+    String? location,
+    String? notes,
+    String? authorId,
+    String? status,
+    Map<String, String>? votes,
+    double? estimatedCostPerPerson,
+    String? estimatedCostCurrency,
+    double? estimatedCostExchangeRate,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return ItineraryItem(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      day: day ?? this.day,
+      time: time ?? this.time,
+      location: location ?? this.location,
+      notes: notes ?? this.notes,
+      authorId: authorId ?? this.authorId,
+      status: status ?? this.status,
+      votes: votes ?? this.votes,
+      estimatedCostPerPerson:
+          estimatedCostPerPerson ?? this.estimatedCostPerPerson,
+      estimatedCostCurrency:
+          estimatedCostCurrency ?? this.estimatedCostCurrency,
+      estimatedCostExchangeRate:
+          estimatedCostExchangeRate ?? this.estimatedCostExchangeRate,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ItineraryItem &&
+          runtimeType == other.runtimeType &&
+          id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
+}

--- a/app/lib/data/models/member.dart
+++ b/app/lib/data/models/member.dart
@@ -1,0 +1,50 @@
+/// Mirrors the `trips/{tripId}/members/{userId}` Firestore document.
+///
+/// See `docs/05-modelo-datos-2.md` §2.2 for the canonical schema.
+/// The [userId] is the Firestore document ID (not stored inside the document).
+class Member {
+  const Member({
+    required this.userId,
+    required this.alias,
+    required this.tags,
+    required this.joinedAt,
+  });
+
+  /// The Firestore document ID — same as the Firebase Auth UID.
+  final String userId;
+
+  /// Alias specific to this trip (may differ from the global user alias).
+  final String alias;
+
+  /// Member preference tags. Keys: "diet", "pace", "budget".
+  /// See `docs/05-modelo-datos-2.md` §2.2 for valid values.
+  final Map<String, dynamic> tags;
+
+  final DateTime joinedAt;
+
+  Member copyWith({
+    String? userId,
+    String? alias,
+    Map<String, dynamic>? tags,
+    DateTime? joinedAt,
+  }) {
+    return Member(
+      userId: userId ?? this.userId,
+      alias: alias ?? this.alias,
+      tags: tags ?? this.tags,
+      joinedAt: joinedAt ?? this.joinedAt,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Member &&
+          runtimeType == other.runtimeType &&
+          userId == other.userId &&
+          alias == other.alias &&
+          joinedAt == other.joinedAt;
+
+  @override
+  int get hashCode => Object.hash(userId, alias, joinedAt);
+}

--- a/app/lib/data/repositories/expense_repository.dart
+++ b/app/lib/data/repositories/expense_repository.dart
@@ -1,0 +1,42 @@
+import 'package:vamos/data/models/expense.dart';
+
+/// Abstract contract for the expenses data source.
+///
+/// Consumers (notifiers, widgets) depend on this type — never on
+/// FirestoreExpenseRepository. See `app/CLAUDE.md` §"Dependencias y override
+/// pattern" for the override contract.
+///
+/// Business rules enforced at this boundary:
+/// - Update is only allowed when [Expense.hasSettlements] is false.
+///   The Firestore security rule also enforces this; the client should
+///   guard before calling [updateExpense] to give fast feedback.
+/// - Delete is only allowed for the creator ([Expense.createdBy]) when
+///   [Expense.hasSettlements] is false.
+abstract class ExpenseRepository {
+  /// Streams all expenses for [tripId], ordered by [date] descending.
+  ///
+  /// The compound index `(date desc, createdAt desc)` declared in
+  /// `firestore.indexes.json` backs this query.
+  Stream<List<Expense>> watchTripExpenses(String tripId);
+
+  /// Streams all expenses for [tripId], ordered by [date] descending.
+  Future<void> createExpense({
+    required String tripId,
+    required Expense expense,
+  });
+
+  /// Updates an existing expense. The caller must verify
+  /// [Expense.hasSettlements] == false before invoking this.
+  /// Each call appends an entry to [Expense.editHistory].
+  Future<void> updateExpense({
+    required String tripId,
+    required Expense expense,
+  });
+
+  /// Deletes an expense. The caller must verify the current user is
+  /// [Expense.createdBy] and [Expense.hasSettlements] == false.
+  Future<void> deleteExpense({
+    required String tripId,
+    required String expenseId,
+  });
+}

--- a/app/lib/data/repositories/firestore_expense_repository.dart
+++ b/app/lib/data/repositories/firestore_expense_repository.dart
@@ -1,0 +1,74 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vamos/data/firebase/firebase_providers.dart';
+import 'package:vamos/data/models/expense.dart';
+import 'package:vamos/data/repositories/expense_repository.dart';
+
+/// Firestore implementation of [ExpenseRepository].
+///
+/// This is the ONLY file in the app that imports `cloud_firestore` for
+/// expenses. Skeleton: methods throw [UnimplementedError] until F3.x
+/// implements the expenses flow. The interface is in place so that notifiers
+/// can depend on [ExpenseRepository] without coupling to Firebase.
+class FirestoreExpenseRepository implements ExpenseRepository {
+  const FirestoreExpenseRepository(this._firestore);
+
+  final FirebaseFirestore _firestore;
+
+  CollectionReference<Map<String, dynamic>> _expenses(String tripId) =>
+      _firestore.collection('trips').doc(tripId).collection('expenses');
+
+  @override
+  Stream<List<Expense>> watchTripExpenses(String tripId) {
+    // TODO(F3-x): implement when the expenses flow is built.
+    throw UnimplementedError('watchTripExpenses is not yet implemented');
+  }
+
+  @override
+  Future<void> createExpense({
+    required String tripId,
+    required Expense expense,
+  }) async {
+    // TODO(F3-x): implement when the expenses flow is built.
+    throw UnimplementedError('createExpense is not yet implemented');
+  }
+
+  @override
+  Future<void> updateExpense({
+    required String tripId,
+    required Expense expense,
+  }) async {
+    // TODO(F3-x): implement when the expenses flow is built.
+    throw UnimplementedError('updateExpense is not yet implemented');
+  }
+
+  @override
+  Future<void> deleteExpense({
+    required String tripId,
+    required String expenseId,
+  }) async {
+    // TODO(F3-x): implement when the expenses flow is built.
+    throw UnimplementedError('deleteExpense is not yet implemented');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Riverpod provider
+// ---------------------------------------------------------------------------
+
+/// Provides the [ExpenseRepository] implementation.
+///
+/// Returns the abstract [ExpenseRepository] type. Override in tests/dev mode:
+///
+/// ```dart
+/// ProviderScope(
+///   overrides: [
+///     expenseRepositoryProvider.overrideWithValue(MockExpenseRepository()),
+///   ],
+///   child: MyApp(),
+/// )
+/// ```
+final expenseRepositoryProvider = Provider<ExpenseRepository>((ref) {
+  final firestore = ref.watch(firestoreProvider);
+  return FirestoreExpenseRepository(firestore);
+});

--- a/app/lib/data/repositories/firestore_itinerary_repository.dart
+++ b/app/lib/data/repositories/firestore_itinerary_repository.dart
@@ -1,0 +1,74 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vamos/data/firebase/firebase_providers.dart';
+import 'package:vamos/data/models/itinerary_item.dart';
+import 'package:vamos/data/repositories/itinerary_repository.dart';
+
+/// Firestore implementation of [ItineraryRepository].
+///
+/// This is the ONLY file in the app that imports `cloud_firestore` for items.
+/// Skeleton: methods throw [UnimplementedError] until F2.x implements the
+/// itinerary flow. The interface is in place so that notifiers can depend on
+/// [ItineraryRepository] without coupling to Firebase.
+class FirestoreItineraryRepository implements ItineraryRepository {
+  const FirestoreItineraryRepository(this._firestore);
+
+  final FirebaseFirestore _firestore;
+
+  CollectionReference<Map<String, dynamic>> _items(String tripId) =>
+      _firestore.collection('trips').doc(tripId).collection('items');
+
+  @override
+  Stream<List<ItineraryItem>> watchTripItems(String tripId) {
+    // TODO(F2-x): implement when the itinerary flow is built.
+    throw UnimplementedError('watchTripItems is not yet implemented');
+  }
+
+  @override
+  Future<void> createItem({
+    required String tripId,
+    required ItineraryItem item,
+  }) async {
+    // TODO(F2-x): implement when the itinerary flow is built.
+    throw UnimplementedError('createItem is not yet implemented');
+  }
+
+  @override
+  Future<void> updateItem({
+    required String tripId,
+    required ItineraryItem item,
+  }) async {
+    // TODO(F2-x): implement when the itinerary flow is built.
+    throw UnimplementedError('updateItem is not yet implemented');
+  }
+
+  @override
+  Future<void> deleteItem({
+    required String tripId,
+    required String itemId,
+  }) async {
+    // TODO(F2-x): implement when the itinerary flow is built.
+    throw UnimplementedError('deleteItem is not yet implemented');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Riverpod provider
+// ---------------------------------------------------------------------------
+
+/// Provides the [ItineraryRepository] implementation.
+///
+/// Returns the abstract [ItineraryRepository] type. Override in tests/dev mode:
+///
+/// ```dart
+/// ProviderScope(
+///   overrides: [
+///     itineraryRepositoryProvider.overrideWithValue(MockItineraryRepository()),
+///   ],
+///   child: MyApp(),
+/// )
+/// ```
+final itineraryRepositoryProvider = Provider<ItineraryRepository>((ref) {
+  final firestore = ref.watch(firestoreProvider);
+  return FirestoreItineraryRepository(firestore);
+});

--- a/app/lib/data/repositories/firestore_member_repository.dart
+++ b/app/lib/data/repositories/firestore_member_repository.dart
@@ -1,0 +1,56 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vamos/data/firebase/firebase_providers.dart';
+import 'package:vamos/data/models/member.dart';
+import 'package:vamos/data/repositories/member_repository.dart';
+
+/// Firestore implementation of [MemberRepository].
+///
+/// This is the ONLY file in the app that imports `cloud_firestore` for members.
+/// Skeleton: methods throw [UnimplementedError] until F1.x implements the
+/// members flow. The interface is in place so that other repos and notifiers
+/// can depend on [MemberRepository] without coupling to Firebase.
+class FirestoreMemberRepository implements MemberRepository {
+  const FirestoreMemberRepository(this._firestore);
+
+  final FirebaseFirestore _firestore;
+
+  CollectionReference<Map<String, dynamic>> _members(String tripId) =>
+      _firestore.collection('trips').doc(tripId).collection('members');
+
+  @override
+  Stream<List<Member>> watchTripMembers(String tripId) {
+    // TODO(F1-x): implement when the members flow is built.
+    throw UnimplementedError('watchTripMembers is not yet implemented');
+  }
+
+  @override
+  Future<Member?> getMember({
+    required String tripId,
+    required String userId,
+  }) async {
+    // TODO(F1-x): implement when the members flow is built.
+    throw UnimplementedError('getMember is not yet implemented');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Riverpod provider
+// ---------------------------------------------------------------------------
+
+/// Provides the [MemberRepository] implementation.
+///
+/// Returns the abstract [MemberRepository] type. Override in tests/dev mode:
+///
+/// ```dart
+/// ProviderScope(
+///   overrides: [
+///     memberRepositoryProvider.overrideWithValue(MockMemberRepository()),
+///   ],
+///   child: MyApp(),
+/// )
+/// ```
+final memberRepositoryProvider = Provider<MemberRepository>((ref) {
+  final firestore = ref.watch(firestoreProvider);
+  return FirestoreMemberRepository(firestore);
+});

--- a/app/lib/data/repositories/firestore_trip_repository.dart
+++ b/app/lib/data/repositories/firestore_trip_repository.dart
@@ -1,0 +1,73 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vamos/data/firebase/firebase_providers.dart';
+import 'package:vamos/data/models/trip.dart';
+import 'package:vamos/data/repositories/trip_repository.dart';
+
+/// Firestore implementation of [TripRepository].
+///
+/// This is the ONLY file in the app that imports `cloud_firestore` for trips.
+/// Widgets, notifiers, and tests never reference this class directly — they
+/// depend on the [TripRepository] abstract type via [tripRepositoryProvider].
+///
+/// See `app/CLAUDE.md` §Hard rules — rule 1.
+class FirestoreTripRepository implements TripRepository {
+  const FirestoreTripRepository(this._firestore);
+
+  final FirebaseFirestore _firestore;
+
+  CollectionReference<Map<String, dynamic>> get _trips =>
+      _firestore.collection('trips');
+
+  // ---------------------------------------------------------------------------
+  // Read
+  // ---------------------------------------------------------------------------
+
+  /// Streams all active trips the [userId] belongs to, ordered by [startDate].
+  ///
+  /// Filters: `memberIds array-contains userId` AND `status == "active"`.
+  /// Sorting by [startDate] ascending is done in Firestore using the compound
+  /// index declared in `firestore.indexes.json`
+  /// (`memberIds array-contains, status, startDate desc`).
+  ///
+  /// The notifier ([MyTripsNotifier]) applies the in-memory sort that groups by
+  /// computed status (ongoing → upcoming → finished → archived) because that
+  /// ordering depends on the current date, which Firestore cannot compute.
+  @override
+  Stream<List<Trip>> watchUserTrips(String userId) {
+    return _trips
+        .where('memberIds', arrayContains: userId)
+        .where('status', isEqualTo: 'active')
+        .orderBy('startDate')
+        .snapshots()
+        .map((snapshot) => snapshot.docs
+            .map((doc) => Trip.fromFirestore(
+                  doc as DocumentSnapshot<Map<String, dynamic>>,
+                ))
+            .toList());
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Riverpod provider
+// ---------------------------------------------------------------------------
+
+/// Provides the [TripRepository] implementation.
+///
+/// Returns the abstract [TripRepository] type — callers never see
+/// [FirestoreTripRepository]. To override in tests or dev mode:
+///
+/// ```dart
+/// ProviderScope(
+///   overrides: [
+///     tripRepositoryProvider.overrideWithValue(MockTripRepository()),
+///   ],
+///   child: MyApp(),
+/// )
+/// ```
+///
+/// Not autoDispose — the repository is stateless and cheap to keep alive.
+final tripRepositoryProvider = Provider<TripRepository>((ref) {
+  final firestore = ref.watch(firestoreProvider);
+  return FirestoreTripRepository(firestore);
+});

--- a/app/lib/data/repositories/itinerary_repository.dart
+++ b/app/lib/data/repositories/itinerary_repository.dart
@@ -1,0 +1,32 @@
+import 'package:vamos/data/models/itinerary_item.dart';
+
+/// Abstract contract for the itinerary items data source.
+///
+/// Consumers (notifiers, widgets) depend on this type — never on
+/// FirestoreItineraryRepository. See `app/CLAUDE.md` §"Dependencias y override
+/// pattern" for the override contract.
+abstract class ItineraryRepository {
+  /// Streams all items for the trip identified by [tripId], ordered by
+  /// [day] ascending then [createdAt] ascending.
+  ///
+  /// The compound index `(day asc, createdAt asc)` declared in
+  /// `firestore.indexes.json` backs this query.
+  Stream<List<ItineraryItem>> watchTripItems(String tripId);
+
+  /// Creates a new itinerary item inside [tripId].
+  Future<void> createItem({
+    required String tripId,
+    required ItineraryItem item,
+  });
+
+  /// Updates an existing item. Only the author or facilitator may call this.
+  /// Enforcement happens in Firestore rules; this method does not re-check.
+  Future<void> updateItem({
+    required String tripId,
+    required ItineraryItem item,
+  });
+
+  /// Deletes an item. Only the author or the trip facilitator may call this.
+  /// Enforcement happens in Firestore rules.
+  Future<void> deleteItem({required String tripId, required String itemId});
+}

--- a/app/lib/data/repositories/member_repository.dart
+++ b/app/lib/data/repositories/member_repository.dart
@@ -1,0 +1,15 @@
+import 'package:vamos/data/models/member.dart';
+
+/// Abstract contract for the trip members data source.
+///
+/// Consumers (notifiers, widgets) depend on this type — never on
+/// FirestoreMemberRepository. See `app/CLAUDE.md` §"Dependencias y override
+/// pattern" for the override contract.
+abstract class MemberRepository {
+  /// Streams all members of the trip identified by [tripId].
+  Stream<List<Member>> watchTripMembers(String tripId);
+
+  /// Returns the member document for [userId] inside [tripId], or null if
+  /// the user is not a member.
+  Future<Member?> getMember({required String tripId, required String userId});
+}

--- a/app/lib/data/repositories/trip_repository.dart
+++ b/app/lib/data/repositories/trip_repository.dart
@@ -1,56 +1,16 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:vamos/data/firebase/firebase_providers.dart';
 import 'package:vamos/data/models/trip.dart';
 
-/// The only place in the codebase that reads/writes the `trips` collection.
+/// Abstract contract for the trips data source.
 ///
-/// Widgets and notifiers never import `cloud_firestore` directly —
-/// they go through this repository. See `app/CLAUDE.md` §Hard rules.
-class TripRepository {
-  const TripRepository(this._firestore);
-
-  final FirebaseFirestore _firestore;
-
-  CollectionReference<Map<String, dynamic>> get _trips =>
-      _firestore.collection('trips');
-
-  // ---------------------------------------------------------------------------
-  // Read
-  // ---------------------------------------------------------------------------
-
+/// The UI and notifiers depend on this type — never on the concrete Firestore
+/// implementation. That makes it trivial to swap the backend, inject a mock in
+/// tests, or run a dev-mode stub without Firebase.
+///
+/// See `app/CLAUDE.md` §"Dependencias y override pattern" for the override
+/// contract and how to provide alternative implementations.
+abstract class TripRepository {
   /// Streams all active trips the [userId] belongs to, ordered by [startDate].
   ///
   /// Filters: `memberIds array-contains userId` AND `status == "active"`.
-  /// Sorting by [startDate] ascending is done in Firestore using the compound
-  /// index declared in `firestore.indexes.json`
-  /// (`memberIds array-contains, status, startDate desc`).
-  ///
-  /// The notifier ([MyTripsNotifier]) applies the in-memory sort that groups by
-  /// computed status (ongoing → upcoming → finished → archived) because that
-  /// ordering depends on the current date, which Firestore cannot compute.
-  Stream<List<Trip>> watchUserTrips(String userId) {
-    return _trips
-        .where('memberIds', arrayContains: userId)
-        .where('status', isEqualTo: 'active')
-        .orderBy('startDate')
-        .snapshots()
-        .map((snapshot) => snapshot.docs
-            .map((doc) => Trip.fromFirestore(
-                  doc as DocumentSnapshot<Map<String, dynamic>>,
-                ))
-            .toList());
-  }
+  Stream<List<Trip>> watchUserTrips(String userId);
 }
-
-// ---------------------------------------------------------------------------
-// Riverpod provider
-// ---------------------------------------------------------------------------
-
-/// Provides the singleton [TripRepository].
-///
-/// Not autoDispose — the repository is stateless and cheap to keep alive.
-final tripRepositoryProvider = Provider<TripRepository>((ref) {
-  final firestore = ref.watch(firestoreProvider);
-  return TripRepository(firestore);
-});

--- a/app/lib/features/trips/application/my_trips_notifier.dart
+++ b/app/lib/features/trips/application/my_trips_notifier.dart
@@ -3,22 +3,45 @@ import 'package:vamos/data/models/trip.dart';
 import 'package:vamos/data/repositories/firestore_trip_repository.dart';
 import 'package:vamos/features/trips/domain/trip_status.dart';
 
+// ---------------------------------------------------------------------------
+// Auth provider — overrideable for tests and dev mode
+// ---------------------------------------------------------------------------
+
+/// Provides the current user's ID.
+///
+/// Default is an empty string (not authenticated). Override in tests or the
+/// dev entry point to inject a fake user ID without Firebase:
+///
+/// ```dart
+/// ProviderScope(
+///   overrides: [
+///     currentUserIdProvider.overrideWithValue('user_test'),
+///     tripRepositoryProvider.overrideWithValue(MockTripRepository()),
+///   ],
+///   child: MyApp(),
+/// )
+/// ```
+///
+/// TODO(E0-06): replace the default implementation with the real auth provider
+/// once Firebase Auth is wired:
+///   `ref.watch(authStateProvider).value?.uid ?? ''`
+final currentUserIdProvider = Provider<String>((ref) => '');
+
+// ---------------------------------------------------------------------------
+// Notifier
+// ---------------------------------------------------------------------------
+
 /// Streams the current user's trips, sorted for the F1.1 list:
-///   ongoing (🟢) → upcoming (🟡) → finished (⚪) → archived (📦).
+///   ongoing → upcoming → finished → archived.
 ///
 /// Within the same [TripStatus] bucket, trips are additionally sorted by
 /// [startDate] ascending (soonest first for upcoming) — the repository
 /// already returns data ordered by startDate from Firestore, so this
 /// secondary sort is preserved naturally.
-///
-/// Auth: if E0-06 (auth) is not yet wired, this notifier falls back to a
-/// [_mockUserId] constant. Replace with the real auth provider when available.
 class MyTripsNotifier extends AutoDisposeStreamNotifier<List<Trip>> {
   @override
   Stream<List<Trip>> build() {
-    // TODO(F1-01): replace with real auth provider once E0-06 is implemented.
-    // e.g. final userId = ref.watch(authStateProvider).value?.uid ?? '';
-    const userId = _mockUserId;
+    final userId = ref.watch(currentUserIdProvider);
 
     if (userId.isEmpty) {
       // Not authenticated yet (E0-06 pending). Emit an empty list so the
@@ -66,13 +89,3 @@ final myTripsProvider =
     AutoDisposeStreamNotifierProvider<MyTripsNotifier, List<Trip>>(
   MyTripsNotifier.new,
 );
-
-// ---------------------------------------------------------------------------
-// Auth mock — remove when E0-06 lands
-// ---------------------------------------------------------------------------
-
-/// Placeholder user ID used until E0-06 (auth) is implemented.
-///
-/// TODO(F1-01): delete this constant and wire [myTripsProvider] to the real
-/// auth provider (e.g. FirebaseAuth.instance.currentUser?.uid).
-const String _mockUserId = '';

--- a/app/lib/features/trips/application/my_trips_notifier.dart
+++ b/app/lib/features/trips/application/my_trips_notifier.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:vamos/data/models/trip.dart';
-import 'package:vamos/data/repositories/trip_repository.dart';
+import 'package:vamos/data/repositories/firestore_trip_repository.dart';
 import 'package:vamos/features/trips/domain/trip_status.dart';
 
 /// Streams the current user's trips, sorted for the F1.1 list:

--- a/app/lib/main_dev.dart
+++ b/app/lib/main_dev.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vamos/app.dart';
+import 'package:vamos/data/repositories/firestore_trip_repository.dart';
+import 'package:vamos/features/trips/application/my_trips_notifier.dart';
+
+import '../test/data/mocks/mock_trip_repository.dart';
+import '../test/data/mocks/trip_fixtures.dart';
+
+/// Development entry point — runs the app without Firebase.
+///
+/// Overrides all data-layer providers with in-memory stubs so you can iterate
+/// on UI without a Firebase project configured on the machine.
+///
+/// Usage:
+///   flutter run -t lib/main_dev.dart
+///
+/// What's active:
+///   - tripRepositoryProvider → MockTripRepository with 3 fixture trips
+///   - currentUserIdProvider  → 'user_dev' (treated as authenticated)
+///
+/// What's NOT active:
+///   - No real Firestore reads/writes
+///   - No Firebase Auth (auth state is faked via currentUserIdProvider)
+///   - Any feature that calls an UnimplementedError repo (Member, Itinerary,
+///     Expense) will throw at runtime — add their mock overrides here when
+///     those flows are being developed.
+void main() {
+  // Firebase.initializeApp() is intentionally absent.
+  // Only firestoreProvider + authProvider are skipped; they are not needed
+  // because all repos are overridden below before they are read.
+  runApp(
+    ProviderScope(
+      overrides: [
+        // Inject a fake user ID so MyTripsNotifier skips the empty-string path.
+        currentUserIdProvider.overrideWithValue('user_dev'),
+
+        // Replace Firestore trips repo with the in-memory mock.
+        tripRepositoryProvider.overrideWithValue(
+          MockTripRepository()..setTrips(TripFixtures.sortedSet()),
+        ),
+      ],
+      child: const VamosApp(),
+    ),
+  );
+}

--- a/app/test/data/mocks/mock_trip_repository.dart
+++ b/app/test/data/mocks/mock_trip_repository.dart
@@ -1,0 +1,42 @@
+import 'package:vamos/data/models/trip.dart';
+import 'package:vamos/data/repositories/trip_repository.dart';
+
+/// In-memory [TripRepository] for tests and dev stubs.
+///
+/// Backed by a mutable list. Call [setTrips] before your test to inject the
+/// desired fixture set, then override the provider in [ProviderScope]:
+///
+/// ```dart
+/// final mock = MockTripRepository();
+/// mock.setTrips([trip1, trip2, trip3]);
+///
+/// await tester.pumpWidget(
+///   ProviderScope(
+///     overrides: [
+///       tripRepositoryProvider.overrideWithValue(mock),
+///     ],
+///     child: MaterialApp.router(routerConfig: router),
+///   ),
+/// );
+/// ```
+///
+/// [watchUserTrips] emits [_trips] once synchronously (via [Stream.value]).
+/// Call [setTrips] again to push a new emission if your test mutates state.
+class MockTripRepository implements TripRepository {
+  final List<Trip> _trips = [];
+
+  /// Replaces the current fixture set. The next subscription to
+  /// [watchUserTrips] will emit this list.
+  void setTrips(List<Trip> trips) {
+    _trips
+      ..clear()
+      ..addAll(trips);
+  }
+
+  @override
+  Stream<List<Trip>> watchUserTrips(String userId) {
+    // Emit the current snapshot synchronously. In tests that use
+    // StreamNotifier, this resolves to AsyncValue.data([...]) immediately.
+    return Stream.value(List<Trip>.from(_trips));
+  }
+}

--- a/app/test/data/mocks/trip_fixtures.dart
+++ b/app/test/data/mocks/trip_fixtures.dart
@@ -1,0 +1,65 @@
+import 'package:vamos/data/models/trip.dart';
+
+/// Shared trip fixtures for tests and the dev entry point (main_dev.dart).
+///
+/// All dates are relative to [DateTime.now()] so the fixtures remain valid
+/// regardless of when tests run. Do not use fixed calendar dates here.
+abstract class TripFixtures {
+  /// An ongoing trip: started 3 days ago, ends in 7 days.
+  static Trip ongoing({String id = 'trip_ongoing'}) {
+    final now = DateTime.now();
+    return Trip(
+      id: id,
+      name: 'Brasil con los del barrio',
+      destination: 'Río de Janeiro',
+      startDate: now.subtract(const Duration(days: 3)),
+      endDate: now.add(const Duration(days: 7)),
+      mainCurrency: 'COP',
+      facilitatorId: 'user_1',
+      memberIds: ['user_1', 'user_2', 'user_3'],
+      status: 'active',
+      createdAt: now.subtract(const Duration(days: 30)),
+      createdBy: 'user_1',
+    );
+  }
+
+  /// An upcoming trip: starts in 60 days.
+  static Trip upcoming({String id = 'trip_upcoming'}) {
+    final now = DateTime.now();
+    return Trip(
+      id: id,
+      name: 'Patagonia express',
+      destination: 'Bariloche',
+      startDate: now.add(const Duration(days: 60)),
+      endDate: now.add(const Duration(days: 70)),
+      mainCurrency: 'ARS',
+      facilitatorId: 'user_2',
+      memberIds: ['user_1', 'user_2'],
+      status: 'active',
+      createdAt: now.subtract(const Duration(days: 10)),
+      createdBy: 'user_2',
+    );
+  }
+
+  /// A finished trip: ended 20 days ago.
+  static Trip finished({String id = 'trip_finished'}) {
+    final now = DateTime.now();
+    return Trip(
+      id: id,
+      name: 'CDMX crew',
+      destination: 'Ciudad de México',
+      startDate: now.subtract(const Duration(days: 30)),
+      endDate: now.subtract(const Duration(days: 20)),
+      mainCurrency: 'MXN',
+      facilitatorId: 'user_3',
+      memberIds: ['user_1', 'user_3'],
+      status: 'active',
+      createdAt: now.subtract(const Duration(days: 60)),
+      createdBy: 'user_3',
+    );
+  }
+
+  /// All three fixtures in the canonical status-sort order:
+  /// ongoing → upcoming → finished.
+  static List<Trip> sortedSet() => [ongoing(), upcoming(), finished()];
+}

--- a/app/test/features/trips/presentation/my_trips_screen_test.dart
+++ b/app/test/features/trips/presentation/my_trips_screen_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:vamos/core/theme/app_theme.dart';
+import 'package:vamos/data/repositories/firestore_trip_repository.dart';
+import 'package:vamos/features/trips/application/my_trips_notifier.dart';
+import 'package:vamos/features/trips/presentation/my_trips_screen.dart';
+
+import '../../../data/mocks/mock_trip_repository.dart';
+import '../../../data/mocks/trip_fixtures.dart';
+
+// ---------------------------------------------------------------------------
+// Test router
+// ---------------------------------------------------------------------------
+
+/// Minimal GoRouter for widget tests.
+/// Only declares /trips so that MyTripsScreen can call context.push('/trips/id')
+/// without crashing; the target route renders a simple Scaffold.
+GoRouter _buildTestRouter() => GoRouter(
+      initialLocation: '/trips',
+      routes: [
+        GoRoute(
+          path: '/trips',
+          builder: (context, state) => const MyTripsScreen(),
+          routes: [
+            GoRoute(
+              path: ':id',
+              builder: (context, state) => const Scaffold(body: Text('detail')),
+            ),
+            GoRoute(
+              path: 'new',
+              builder: (context, state) => const Scaffold(body: Text('new')),
+            ),
+          ],
+        ),
+      ],
+    );
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+/// Pumps [MyTripsScreen] inside a [ProviderScope] that overrides both the
+/// repository and the user ID, so no Firebase is needed.
+Future<void> pumpMyTripsScreen(
+  WidgetTester tester, {
+  required MockTripRepository repo,
+  String userId = 'user_1',
+}) async {
+  final testRouter = _buildTestRouter();
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        tripRepositoryProvider.overrideWithValue(repo),
+        currentUserIdProvider.overrideWithValue(userId),
+      ],
+      child: MaterialApp.router(
+        theme: AppTheme.light(),
+        routerConfig: testRouter,
+      ),
+    ),
+  );
+
+  // Allow the StreamNotifier to resolve its first emission.
+  await tester.pump();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('MyTripsScreen — sorting + status badges', () {
+    test('MockTripRepository emits the injected list', () async {
+      // Verify the mock works independently before involving widgets.
+      final mock = MockTripRepository();
+      mock.setTrips(TripFixtures.sortedSet());
+
+      final result = await mock.watchUserTrips('user_1').first;
+      expect(result.length, 3);
+      expect(result[0].name, 'Brasil con los del barrio');
+      expect(result[1].name, 'Patagonia express');
+      expect(result[2].name, 'CDMX crew');
+    });
+
+    testWidgets('renders all three trip names', (tester) async {
+      final mock = MockTripRepository()
+        ..setTrips(TripFixtures.sortedSet());
+
+      await pumpMyTripsScreen(tester, repo: mock);
+
+      expect(find.text('Brasil con los del barrio'), findsOneWidget);
+      expect(find.text('Patagonia express'), findsOneWidget);
+      expect(find.text('CDMX crew'), findsOneWidget);
+    });
+
+    testWidgets('ongoing trip shows "En curso" badge', (tester) async {
+      final mock = MockTripRepository()
+        ..setTrips([TripFixtures.ongoing()]);
+
+      await pumpMyTripsScreen(tester, repo: mock);
+
+      // The badge starts with "En curso". Use a prefix finder.
+      expect(
+        find.textContaining('En curso'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('upcoming trip shows "Por planear" badge', (tester) async {
+      final mock = MockTripRepository()
+        ..setTrips([TripFixtures.upcoming()]);
+
+      await pumpMyTripsScreen(tester, repo: mock);
+
+      expect(
+        find.textContaining('Por planear'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('finished trip shows "Terminado" badge', (tester) async {
+      final mock = MockTripRepository()
+        ..setTrips([TripFixtures.finished()]);
+
+      await pumpMyTripsScreen(tester, repo: mock);
+
+      expect(find.text('Terminado'), findsOneWidget);
+    });
+
+    testWidgets('status sort order: ongoing before upcoming before finished',
+        (tester) async {
+      // Inject in the reverse order to confirm the notifier re-sorts.
+      final mock = MockTripRepository()
+        ..setTrips([
+          TripFixtures.finished(),   // would be last after sort
+          TripFixtures.upcoming(),   // would be second
+          TripFixtures.ongoing(),    // would be first
+        ]);
+
+      await pumpMyTripsScreen(tester, repo: mock);
+
+      // Collect all TripCard widgets via trip name Text widgets.
+      // The vertical order in ListView reflects sort order.
+      final ongoingOffset =
+          tester.getTopLeft(find.text('Brasil con los del barrio')).dy;
+      final upcomingOffset =
+          tester.getTopLeft(find.text('Patagonia express')).dy;
+      final finishedOffset =
+          tester.getTopLeft(find.text('CDMX crew')).dy;
+
+      expect(ongoingOffset, lessThan(upcomingOffset),
+          reason: 'ongoing must appear before upcoming');
+      expect(upcomingOffset, lessThan(finishedOffset),
+          reason: 'upcoming must appear before finished');
+    });
+
+    testWidgets('empty list shows empty-state copy', (tester) async {
+      final mock = MockTripRepository()..setTrips([]);
+
+      await pumpMyTripsScreen(tester, repo: mock);
+
+      expect(find.text('Acá no hay nada todavía.'), findsOneWidget);
+      expect(
+        find.textContaining('Creá un viaje'),
+        findsOneWidget,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #46

## Summary

- Establishes the repository abstraction discipline for all 4 MVP data repos (Trip, Member, Itinerary, Expense): each is split into an `abstract class` contract and a `FirestoreXxxRepository` implementation, with the Riverpod provider returning the abstract type.
- Adds `currentUserIdProvider` (overrideable) to replace the hardcoded `_mockUserId` constant in `MyTripsNotifier`, enabling clean test and dev overrides without Firebase.
- Adds `MockTripRepository` + `TripFixtures` as shared test infrastructure, and a `MyTripsScreen` widget test that validates trip name rendering, status badges, sort order, and empty state — all without Firebase.
- Adds `lib/main_dev.dart` as a Firebase-free development entry point with 3 fixture trips pre-loaded.
- Adds `app/CLAUDE.md` §"Dependencias y override pattern" documenting the full convention (when to abstract, how to override in tests/dev/web, hypothetical backend migration walkthrough).

## Changes

### Refactored
- `app/lib/data/repositories/trip_repository.dart` → now an `abstract class` (no Firebase imports)
- `app/lib/data/repositories/firestore_trip_repository.dart` → new file, Firestore impl + provider
- `app/lib/features/trips/application/my_trips_notifier.dart` → replaced hardcoded `_mockUserId` with `currentUserIdProvider`

### New — repository skeletons
- `app/lib/data/models/member.dart`
- `app/lib/data/models/itinerary_item.dart`
- `app/lib/data/models/expense.dart`
- `app/lib/data/repositories/member_repository.dart` + `firestore_member_repository.dart`
- `app/lib/data/repositories/itinerary_repository.dart` + `firestore_itinerary_repository.dart`
- `app/lib/data/repositories/expense_repository.dart` + `firestore_expense_repository.dart`

### New — test infrastructure
- `app/test/data/mocks/mock_trip_repository.dart`
- `app/test/data/mocks/trip_fixtures.dart`
- `app/test/features/trips/presentation/my_trips_screen_test.dart`

### New — dev entry point
- `app/lib/main_dev.dart` (`flutter run -t lib/main_dev.dart`)

### Docs
- `app/CLAUDE.md` §"Dependencias y override pattern"

## Coordination note

`MyTripsNotifier` previously used `const _mockUserId = ''`. This PR replaces that with `currentUserIdProvider.overrideWithValue('user_dev')` in `main_dev.dart`. If PR #45 (F1-01) is still open and also touches `my_trips_notifier.dart`, coordinate the merge order to avoid conflicts.

## Test plan

- [ ] `flutter analyze` — no issues (Flutter not available in CI environment; verify locally)
- [ ] `flutter test` — all existing tests pass; new `my_trips_screen_test.dart` passes
- [ ] Run `flutter run -t lib/main_dev.dart` on a device — F1.1 screen shows 3 fixture trips with correct status badges and sort order, no Firebase errors
- [ ] Confirm no feature file imports `cloud_firestore` directly (only `firestore_*.dart` files do)

https://claude.ai/code/session_01DKr74oW7cHAncSbDuCQxPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01DKr74oW7cHAncSbDuCQxPK)_