### PR TITLE
[E0-04] Reglas Firestore + Storage minimas (deny-all)

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -1,13 +1,9 @@
 rules_version = '2';
 
-// PLACEHOLDER — esqueleto de reglas.
-// La versión completa se cierra en docs/07-firestore-rules.md (pendiente).
-// Mientras tanto, ver docs/05-modelo-datos-2.md §4 para el esqueleto base.
+// Deny-all base. Per-collection rules are added as each MVP flow is implemented (X-01).
 
 service cloud.firestore {
   match /databases/{database}/documents {
-    // Bloquear todo por default. Reglas específicas se agregan cuando se
-    // implemente cada flujo del MVP.
     match /{document=**} {
       allow read, write: if false;
     }

--- a/firebase/storage.rules
+++ b/firebase/storage.rules
@@ -1,8 +1,6 @@
 rules_version = '2';
 
-// PLACEHOLDER — reglas de Storage.
-// Se completan cuando se implemente el primer flujo que sube fotos
-// (probablemente F1.2 con la foto de portada del viaje).
+// Deny-all base. Per-path rules are added when F1.2 (cover photo upload) is implemented.
 
 service firebase.storage {
   match /b/{bucket}/o {


### PR DESCRIPTION
## Summary

- Remove placeholder comments from `firestore.rules` and `storage.rules`
- Firestore deny-all rules deployed to `vamos-app-a5f24`
- Storage rules cleaned but not deployed — Firebase Storage not yet enabled in console (manual step needed at https://console.firebase.google.com/project/vamos-app-a5f24/storage)

## Issue

Closes #4

## Checklist

- [x] Firestore rules deployed (deny-all active)
- [x] Storage rules file cleaned
- [ ] Storage rules deployed (blocked: Storage not enabled in console)