### PR TITLE
[E0-06] Splash + auth con Google y Apple Sign-In

### DIFF
--- a/app/lib/core/router/app_router.dart
+++ b/app/lib/core/router/app_router.dart
@@ -1,19 +1,71 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:vamos/features/auth/presentation/login_screen.dart';
 import 'package:vamos/features/trips/presentation/my_trips_screen.dart';
+
+// ---------------------------------------------------------------------------
+// Auth change notifier — bridges Firebase Auth stream to GoRouter
+// ---------------------------------------------------------------------------
+
+/// A thin [ChangeNotifier] that listens to [FirebaseAuth.authStateChanges]
+/// and calls [notifyListeners] on every emission.
+///
+/// Used as [GoRouter.refreshListenable] so the router re-evaluates the
+/// redirect whenever auth state changes (sign-in, sign-out, token refresh).
+/// Accessing [FirebaseAuth] here directly is acceptable — this is router
+/// config, not UI or business logic.
+class _AuthChangeNotifier extends ChangeNotifier {
+  _AuthChangeNotifier() {
+    _subscription = FirebaseAuth.instance.authStateChanges().listen(
+      (_) => notifyListeners(),
+    );
+  }
+
+  late final dynamic _subscription;
+
+  @override
+  void dispose() {
+    _subscription.cancel();
+    super.dispose();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
 
 /// Application router.
 ///
-/// Routes declared here:
+/// Routes:
+///   /login          → [LoginScreen]    (unauthenticated)
 ///   /trips          → [MyTripsScreen]  (authenticated home, F1.1)
-///   /trips/new      → stub for F1.2 (create trip form)
-///   /trips/:id      → stub for F2.1 (trip shell with tabs)
+///   /trips/new      → stub for F1.2
+///   /trips/:id      → stub for F2.1
 ///
-/// Auth redirect is not wired yet — it will be added when E0-06 (auth) lands.
-/// TODO(F1-01): add redirect in refreshListenable once authStateProvider exists.
+/// Redirect logic:
+///   - Not signed in → /login (from any route)
+///   - Signed in on /login → /trips
 final router = GoRouter(
   initialLocation: '/trips',
+  refreshListenable: _AuthChangeNotifier(),
+  redirect: (context, state) {
+    final isLoggedIn = FirebaseAuth.instance.currentUser != null;
+    final isOnLogin = state.matchedLocation == '/login';
+
+    if (!isLoggedIn && !isOnLogin) return '/login';
+    if (isLoggedIn && isOnLogin) return '/trips';
+    return null;
+  },
   routes: [
+    // -------------------------------------------------------------------------
+    // Login / splash (unauthenticated)
+    // -------------------------------------------------------------------------
+    GoRoute(
+      path: '/login',
+      builder: (context, state) => const LoginScreen(),
+    ),
+
     // -------------------------------------------------------------------------
     // Authenticated home: Mis viajes (F1.1)
     // -------------------------------------------------------------------------

--- a/app/lib/data/firebase/firebase_providers.dart
+++ b/app/lib/data/firebase/firebase_providers.dart
@@ -19,10 +19,6 @@ final firestoreProvider = Provider<FirebaseFirestore>((ref) {
   return FirebaseFirestore.instance;
 });
 
-/// Exposes the current [User] as a stream.
-///
-/// autoDispose because any screen that cares about auth state manages its
-/// own lifecycle. The auth redirect lives in the router, not here.
-final authStateProvider = StreamProvider.autoDispose<User?>((ref) {
-  return ref.watch(authProvider).authStateChanges();
-});
+// authStateProvider is defined in features/auth/application/auth_notifier.dart.
+// It is a global (no autoDispose) StreamProvider<User?> that the router
+// refresh listens to. Import it from there — do not duplicate it here.

--- a/app/lib/features/auth/application/auth_notifier.dart
+++ b/app/lib/features/auth/application/auth_notifier.dart
@@ -1,0 +1,60 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vamos/features/auth/data/firestore_auth_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Auth state stream — global, no autoDispose
+// ---------------------------------------------------------------------------
+
+/// Streams the current [User] from Firebase Auth.
+///
+/// Emits `null` when the user is not signed in.
+/// Not autoDispose — the auth state must outlive any individual screen
+/// so the router redirect stays alive throughout the app lifecycle.
+final authStateProvider = StreamProvider<User?>((ref) {
+  return ref.watch(authRepositoryProvider).authStateChanges();
+});
+
+// ---------------------------------------------------------------------------
+// Sign-in / sign-out actions
+// ---------------------------------------------------------------------------
+
+/// Handles Google Sign-In, Apple Sign-In, and Sign-Out mutations.
+///
+/// Each action sets [state] to [AsyncLoading] while in flight, then to
+/// [AsyncData] or [AsyncError] upon completion. The router redirect reacts
+/// to [authStateProvider], so there is no need for the screen to navigate
+/// manually after a successful sign-in.
+///
+/// autoDispose: the login screen owns the lifecycle. When the user navigates
+/// away (because they are now authenticated), the notifier is disposed.
+class AuthActionsNotifier extends AutoDisposeAsyncNotifier<void> {
+  @override
+  Future<void> build() async {}
+
+  Future<void> signInWithGoogle() async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(
+      () => ref.read(authRepositoryProvider).signInWithGoogle(),
+    );
+  }
+
+  Future<void> signInWithApple() async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(
+      () => ref.read(authRepositoryProvider).signInWithApple(),
+    );
+  }
+
+  Future<void> signOut() async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(
+      () => ref.read(authRepositoryProvider).signOut(),
+    );
+  }
+}
+
+final authActionsProvider =
+    AsyncNotifierProvider.autoDispose<AuthActionsNotifier, void>(
+  AuthActionsNotifier.new,
+);

--- a/app/lib/features/auth/data/auth_repository.dart
+++ b/app/lib/features/auth/data/auth_repository.dart
@@ -1,0 +1,27 @@
+import 'package:firebase_auth/firebase_auth.dart';
+
+/// Contract for the auth layer.
+///
+/// The UI layer never touches Firebase directly — all auth operations are
+/// channelled through this interface. The concrete [FirestoreAuthRepository]
+/// (in `firestore_auth_repository.dart`) is the only file that imports
+/// `firebase_auth` for actual sign-in calls.
+abstract class AuthRepository {
+  /// Stream that emits whenever the auth state changes.
+  ///
+  /// Emits [User] when the user is signed in, `null` when signed out.
+  Stream<User?> authStateChanges();
+
+  /// Sign in with a Google account.
+  ///
+  /// Throws [FirebaseAuthException] on failure.
+  Future<UserCredential> signInWithGoogle();
+
+  /// Sign in with an Apple account.
+  ///
+  /// Throws [SignInWithAppleException] or [FirebaseAuthException] on failure.
+  Future<UserCredential> signInWithApple();
+
+  /// Sign out the current user from Firebase and the social provider.
+  Future<void> signOut();
+}

--- a/app/lib/features/auth/data/firestore_auth_repository.dart
+++ b/app/lib/features/auth/data/firestore_auth_repository.dart
@@ -1,0 +1,80 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
+import 'package:vamos/data/firebase/firebase_providers.dart';
+import 'auth_repository.dart';
+
+/// Firebase / social-SDK implementation of [AuthRepository].
+///
+/// This is the only file in the auth feature that talks to Firebase Auth
+/// and the native sign-in SDKs. Notifiers and widgets only depend on
+/// [AuthRepository].
+///
+/// NOTE (prod): for Google Sign-In to work on Android, the SHA-1 fingerprint
+/// of the signing key must be added to the Firebase console under
+/// Project Settings → Your apps → Android → SHA certificate fingerprints.
+/// Debug SHA-1: run `./gradlew signingReport` inside `app/android/`.
+class FirebaseAuthRepository implements AuthRepository {
+  FirebaseAuthRepository(this._auth);
+
+  final FirebaseAuth _auth;
+
+  @override
+  Stream<User?> authStateChanges() => _auth.authStateChanges();
+
+  @override
+  Future<UserCredential> signInWithGoogle() async {
+    // Trigger the Google Authentication flow.
+    final googleUser = await GoogleSignIn().signIn();
+    if (googleUser == null) {
+      // The user cancelled the sign-in dialog.
+      throw FirebaseAuthException(
+        code: 'sign-in-cancelled',
+        message: 'El inicio de sesión con Google fue cancelado.',
+      );
+    }
+
+    // Obtain the Google auth credentials.
+    final googleAuth = await googleUser.authentication;
+    final credential = GoogleAuthProvider.credential(
+      accessToken: googleAuth.accessToken,
+      idToken: googleAuth.idToken,
+    );
+
+    return _auth.signInWithCredential(credential);
+  }
+
+  @override
+  Future<UserCredential> signInWithApple() async {
+    // Request Apple credentials.
+    final appleCredential = await SignInWithApple.getAppleIDCredential(
+      scopes: [
+        AppleIDAuthorizationScopes.email,
+        AppleIDAuthorizationScopes.fullName,
+      ],
+    );
+
+    // Create an OAuthCredential from the Apple credential.
+    final oauthCredential = OAuthProvider('apple.com').credential(
+      idToken: appleCredential.identityToken,
+      accessToken: appleCredential.authorizationCode,
+    );
+
+    return _auth.signInWithCredential(oauthCredential);
+  }
+
+  @override
+  Future<void> signOut() async {
+    await GoogleSignIn().signOut();
+    await _auth.signOut();
+  }
+}
+
+/// Provider that exposes [AuthRepository].
+///
+/// Consumers depend on the abstract type. The concrete [FirebaseAuthRepository]
+/// is wired here. Swap to a mock in tests by overriding this provider.
+final authRepositoryProvider = Provider<AuthRepository>((ref) {
+  return FirebaseAuthRepository(ref.watch(authProvider));
+});

--- a/app/lib/features/auth/presentation/login_screen.dart
+++ b/app/lib/features/auth/presentation/login_screen.dart
@@ -1,0 +1,188 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vamos/core/theme/vamos_colors.dart';
+import 'package:vamos/core/theme/vamos_logo.dart';
+import 'package:vamos/core/theme/vamos_spacing.dart';
+import 'package:vamos/core/theme/vamos_typography.dart';
+import 'package:vamos/features/auth/application/auth_notifier.dart';
+
+/// Splash / login screen (E0-06).
+///
+/// Shown when the user is not authenticated. Provides Google and Apple
+/// Sign-In buttons. Design is intentionally minimal — functional only.
+/// Navigation to /trips is handled by the router redirect, not here.
+class LoginScreen extends ConsumerWidget {
+  const LoginScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final authActions = ref.watch(authActionsProvider);
+    final isLoading = authActions.isLoading;
+
+    // Show SnackBar on error.
+    ref.listen<AsyncValue<void>>(authActionsProvider, (_, next) {
+      next.whenOrNull(
+        error: (error, _) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                _friendlyError(error),
+                style: VamosTypography.bodyMedium.copyWith(
+                  color: VamosColors.textOnDark,
+                ),
+              ),
+              backgroundColor: VamosColors.red,
+            ),
+          );
+        },
+      );
+    });
+
+    return Scaffold(
+      backgroundColor: VamosColors.bg,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: VamosSpacing.lg),
+          child: Column(
+            children: [
+              // Top spacer — push logo to ~40% from top.
+              const Spacer(flex: 3),
+
+              // Logo
+              const VamosLogo(size: 56),
+
+              const SizedBox(height: VamosSpacing.sm),
+
+              // Tagline
+              Text(
+                'Viajá con tu gente',
+                style: VamosTypography.bodyMedium.copyWith(
+                  color: VamosColors.text3,
+                ),
+              ),
+
+              // Bottom spacer — buttons towards 2/3 of screen.
+              const Spacer(flex: 2),
+
+              // Google Sign-In button
+              _SignInButton(
+                label: 'Continuar con Google',
+                icon: _GoogleIcon(),
+                onPressed: isLoading
+                    ? null
+                    : () => ref
+                        .read(authActionsProvider.notifier)
+                        .signInWithGoogle(),
+              ),
+
+              const SizedBox(height: VamosSpacing.md),
+
+              // Apple Sign-In button (iOS only)
+              if (Platform.isIOS) ...[
+                _SignInButton(
+                  label: 'Continuar con Apple',
+                  icon: const Icon(
+                    Icons.apple,
+                    size: 22,
+                    color: VamosColors.text,
+                  ),
+                  onPressed: isLoading
+                      ? null
+                      : () => ref
+                          .read(authActionsProvider.notifier)
+                          .signInWithApple(),
+                ),
+                const SizedBox(height: VamosSpacing.md),
+              ],
+
+              // Loading indicator
+              if (isLoading)
+                const Padding(
+                  padding: EdgeInsets.only(bottom: VamosSpacing.md),
+                  child: CircularProgressIndicator(),
+                ),
+
+              // Terms note
+              Text(
+                'Al continuar aceptás los términos de uso.',
+                style: VamosTypography.caption.copyWith(
+                  color: VamosColors.textMuted,
+                ),
+                textAlign: TextAlign.center,
+              ),
+
+              const SizedBox(height: VamosSpacing.lg),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _friendlyError(Object error) {
+    final msg = error.toString();
+    if (msg.contains('sign-in-cancelled') || msg.contains('canceled')) {
+      return 'El inicio de sesión fue cancelado.';
+    }
+    if (msg.contains('network-request-failed')) {
+      return 'Sin conexión. Revisá tu red e intentá de nuevo.';
+    }
+    return 'No se pudo iniciar sesión. Intentá de nuevo.';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal widgets
+// ---------------------------------------------------------------------------
+
+class _SignInButton extends StatelessWidget {
+  const _SignInButton({
+    required this.label,
+    required this.icon,
+    required this.onPressed,
+  });
+
+  final String label;
+  final Widget icon;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: OutlinedButton.icon(
+        icon: icon,
+        label: Text(label),
+        onPressed: onPressed,
+        style: OutlinedButton.styleFrom(
+          foregroundColor: VamosColors.text,
+          side: const BorderSide(color: VamosColors.border),
+          padding: const EdgeInsets.symmetric(vertical: VamosSpacing.md),
+          textStyle: VamosTypography.titleMedium,
+          shape: const RoundedRectangleBorder(
+            borderRadius: VamosRadius.brFull,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Minimal Google "G" icon built with a Text widget to avoid adding
+/// an external asset or package dependency.
+class _GoogleIcon extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return const Text(
+      'G',
+      style: TextStyle(
+        fontFamily: VamosTypography.fontDisplay,
+        fontWeight: FontWeight.w700,
+        fontSize: 18,
+        color: VamosColors.sol500,
+      ),
+    );
+  }
+}

--- a/app/lib/features/trips/application/my_trips_notifier.dart
+++ b/app/lib/features/trips/application/my_trips_notifier.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:vamos/data/models/trip.dart';
 import 'package:vamos/data/repositories/firestore_trip_repository.dart';
+import 'package:vamos/features/auth/application/auth_notifier.dart';
 import 'package:vamos/features/trips/domain/trip_status.dart';
 
 // ---------------------------------------------------------------------------
@@ -9,8 +10,11 @@ import 'package:vamos/features/trips/domain/trip_status.dart';
 
 /// Provides the current user's ID.
 ///
-/// Default is an empty string (not authenticated). Override in tests or the
-/// dev entry point to inject a fake user ID without Firebase:
+/// Derived from [authStateProvider] so it automatically updates when the
+/// user signs in or out. Returns an empty string when not authenticated.
+///
+/// Override in tests or the dev entry point to inject a fake user ID without
+/// Firebase:
 ///
 /// ```dart
 /// ProviderScope(
@@ -21,11 +25,9 @@ import 'package:vamos/features/trips/domain/trip_status.dart';
 ///   child: MyApp(),
 /// )
 /// ```
-///
-/// TODO(E0-06): replace the default implementation with the real auth provider
-/// once Firebase Auth is wired:
-///   `ref.watch(authStateProvider).value?.uid ?? ''`
-final currentUserIdProvider = Provider<String>((ref) => '');
+final currentUserIdProvider = Provider<String>((ref) {
+  return ref.watch(authStateProvider).value?.uid ?? '';
+});
 
 // ---------------------------------------------------------------------------
 // Notifier

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -40,6 +40,10 @@ dependencies:
   firebase_auth: ^5.5.4
   cloud_firestore: ^5.6.7
 
+  # Auth providers
+  google_sign_in: ^6.2.2
+  sign_in_with_apple: ^6.1.4
+
   # State management
   flutter_riverpod: ^2.6.1
 


### PR DESCRIPTION
## Summary

- Add `google_sign_in ^6.2.2` and `sign_in_with_apple ^6.1.4` to pubspec
- `features/auth/data/auth_repository.dart` — abstract contract
- `features/auth/data/firestore_auth_repository.dart` — Firebase impl + provider
- `features/auth/application/auth_notifier.dart` — global `authStateProvider` (StreamProvider<User?>)
- `features/auth/presentation/login_screen.dart` — VamosLogo + Google/Apple buttons + loading/error state
- `core/router/app_router.dart` — `/login` route + auth redirect via `refreshListenable`
- `currentUserIdProvider` now reads real auth state

Note: Android SHA-1 fingerprint must be registered in Firebase console for Google Sign-In in release builds.

## Issue

Closes #6

## Checklist

- [x] google_sign_in + sign_in_with_apple added
- [x] Auth repository (abstract + Firebase impl)
- [x] authStateProvider wired
- [x] Login screen functional
- [x] Router redirect on auth state
- [x] flutter analyze clean