### PR TITLE
[E0-08] Logging basico

### DIFF
--- a/app/lib/core/utils/logger.dart
+++ b/app/lib/core/utils/logger.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/foundation.dart';
+import 'package:logger/logger.dart';
+
+// App-wide logger. Use `log.d(...)`, `log.i(...)`, `log.w(...)`, `log.e(...)`.
+// Debug builds: all levels. Release builds: warnings and above only.
+final log = Logger(
+  level: kDebugMode ? Level.debug : Level.warning,
+  printer: PrettyPrinter(
+    methodCount: 0,
+    errorMethodCount: 5,
+    lineLength: 80,
+    colors: kDebugMode,
+    printEmojis: true,
+  ),
+);

--- a/app/lib/features/auth/data/firestore_auth_repository.dart
+++ b/app/lib/features/auth/data/firestore_auth_repository.dart
@@ -2,6 +2,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
+import 'package:vamos/core/utils/logger.dart';
 import 'package:vamos/data/firebase/firebase_providers.dart';
 import 'auth_repository.dart';
 
@@ -42,6 +43,7 @@ class FirebaseAuthRepository implements AuthRepository {
       idToken: googleAuth.idToken,
     );
 
+    log.i('Google Sign-In: credential obtained for ${googleUser.email}');
     return _auth.signInWithCredential(credential);
   }
 
@@ -61,11 +63,13 @@ class FirebaseAuthRepository implements AuthRepository {
       accessToken: appleCredential.authorizationCode,
     );
 
+    log.i('Apple Sign-In: credential obtained');
     return _auth.signInWithCredential(oauthCredential);
   }
 
   @override
   Future<void> signOut() async {
+    log.i('Signing out');
     await GoogleSignIn().signOut();
     await _auth.signOut();
   }

--- a/app/lib/features/trips/application/my_trips_notifier.dart
+++ b/app/lib/features/trips/application/my_trips_notifier.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vamos/core/utils/logger.dart';
 import 'package:vamos/data/models/trip.dart';
 import 'package:vamos/data/repositories/firestore_trip_repository.dart';
 import 'package:vamos/features/auth/application/auth_notifier.dart';
@@ -46,13 +47,11 @@ class MyTripsNotifier extends AutoDisposeStreamNotifier<List<Trip>> {
     final userId = ref.watch(currentUserIdProvider);
 
     if (userId.isEmpty) {
-      // Not authenticated yet (E0-06 pending). Emit an empty list so the
-      // notifier resolves to AsyncValue.data([]) instead of staying stuck
-      // in loading. Stream.empty() closes without emitting, which would
-      // freeze the screen on the loading spinner.
+      log.d('MyTripsNotifier: no authenticated user, emitting empty list');
       return Stream.value(const <Trip>[]);
     }
 
+    log.d('MyTripsNotifier: watching trips for user $userId');
     return ref
         .watch(tripRepositoryProvider)
         .watchUserTrips(userId)

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -50,6 +50,9 @@ dependencies:
   # Navigation
   go_router: ^15.1.2
 
+  # Logging
+  logger: ^2.5.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary

- Add `logger: ^2.5.0` to pubspec
- `core/utils/logger.dart` — singleton `log` with level `DEBUG` in dev, `WARNING` in prod (via `kDebugMode`)
- Wired into `firestore_auth_repository.dart` (sign-in/sign-out events) and `my_trips_notifier.dart` (auth state + trip watch)

## Issue

Closes #8

## Checklist

- [x] logger package added
- [x] Logger singleton in core/utils
- [x] Used in 2+ existing files
- [x] flutter analyze clean