### PR TITLE
[F1-03] Generar link publico de invitacion (F1.3)

### DIFF
--- a/app/lib/core/router/app_router.dart
+++ b/app/lib/core/router/app_router.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:vamos/features/auth/presentation/login_screen.dart';
 import 'package:vamos/features/trips/presentation/create_trip_screen.dart';
+import 'package:vamos/features/trips/presentation/invite_screen.dart';
 import 'package:vamos/features/trips/presentation/my_trips_screen.dart';
 
 // ---------------------------------------------------------------------------
@@ -39,10 +40,11 @@ class _AuthChangeNotifier extends ChangeNotifier {
 /// Application router.
 ///
 /// Routes:
-///   /login          → [LoginScreen]       (unauthenticated)
-///   /trips          → [MyTripsScreen]     (authenticated home, F1.1)
-///   /trips/new      → [CreateTripScreen]  (create trip form, F1.2)
-///   /trips/:id      → stub for F2.1
+///   /login                    → [LoginScreen]    (unauthenticated)
+///   /trips                    → [MyTripsScreen]  (authenticated home, F1.1)
+///   /trips/new                → [CreateTripScreen] (create trip form, F1.2)
+///   /trips/:id/invite         → [InviteScreen]   (success + share link, F1.3)
+///   /trips/:id                → stub for F2.1
 ///
 /// Redirect logic:
 ///   - Not signed in → /login (from any route)
@@ -86,6 +88,16 @@ final router = GoRouter(
             final tripId = state.pathParameters['id']!;
             return _StubScreen(title: 'Viaje $tripId');
           },
+          routes: [
+            // F1.3 — Success + invite-link screen.
+            GoRoute(
+              path: 'invite',
+              builder: (context, state) {
+                final tripId = state.pathParameters['id']!;
+                return InviteScreen(tripId: tripId);
+              },
+            ),
+          ],
         ),
       ],
     ),

--- a/app/lib/data/models/invite.dart
+++ b/app/lib/data/models/invite.dart
@@ -1,0 +1,52 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Mirrors the `invites/{code}` Firestore document.
+///
+/// See `docs/05-modelo-datos-2.md` for the canonical schema.
+/// The [code] is the Firestore document ID — it doubles as the URL slug
+/// (`vamos.app/j/{code}`) and is NOT stored inside the document itself.
+class Invite {
+  const Invite({
+    required this.code,
+    required this.tripId,
+    required this.createdBy,
+    required this.createdAt,
+    required this.active,
+  });
+
+  /// 6-character invite code, also the Firestore document ID.
+  final String code;
+  final String tripId;
+  final String createdBy;
+  final DateTime createdAt;
+
+  /// False when the facilitator has revoked the link (F1-08, not in MVP).
+  final bool active;
+
+  // ---------------------------------------------------------------------------
+  // Serialization
+  // ---------------------------------------------------------------------------
+
+  /// Creates an [Invite] from a Firestore [DocumentSnapshot].
+  factory Invite.fromFirestore(DocumentSnapshot<Map<String, dynamic>> doc) {
+    final data = doc.data()!;
+    return Invite(
+      code: doc.id,
+      tripId: data['tripId'] as String,
+      createdBy: data['createdBy'] as String,
+      createdAt: (data['createdAt'] as Timestamp).toDate(),
+      active: data['active'] as bool,
+    );
+  }
+
+  /// Serializes to a Firestore-compatible map.
+  /// The document [code] is NOT included — it lives as the document key.
+  Map<String, dynamic> toFirestore() {
+    return {
+      'tripId': tripId,
+      'createdBy': createdBy,
+      'createdAt': Timestamp.fromDate(createdAt),
+      'active': active,
+    };
+  }
+}

--- a/app/lib/data/repositories/firestore_invite_repository.dart
+++ b/app/lib/data/repositories/firestore_invite_repository.dart
@@ -1,0 +1,104 @@
+import 'dart:math';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vamos/data/firebase/firebase_providers.dart';
+import 'package:vamos/data/models/invite.dart';
+import 'package:vamos/data/repositories/invite_repository.dart';
+
+/// Firestore implementation of [InviteRepository].
+///
+/// This is the ONLY file in the app that imports `cloud_firestore` for invites.
+/// Widgets, notifiers, and tests never reference this class directly — they
+/// depend on the [InviteRepository] abstract type via [inviteRepositoryProvider].
+///
+/// Code generation charset excludes visually ambiguous characters
+/// (0, O, 1, I, L) to prevent read errors when the code is shared verbally.
+/// With 30 chars and length 6 → 30^6 = 729 million combinations.
+class FirestoreInviteRepository implements InviteRepository {
+  const FirestoreInviteRepository(this._firestore);
+
+  final FirebaseFirestore _firestore;
+
+  // Charset excludes: 0, O, 1, I, L for readability when shared verbally.
+  static const String _charset = '23456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+  CollectionReference<Map<String, dynamic>> get _invites =>
+      _firestore.collection('invites');
+
+  // ---------------------------------------------------------------------------
+  // Code generation
+  // ---------------------------------------------------------------------------
+
+  String _generateCode() {
+    final rng = Random.secure();
+    return List.generate(6, (_) => _charset[rng.nextInt(_charset.length)])
+        .join();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Write
+  // ---------------------------------------------------------------------------
+
+  /// Creates an invite document at `invites/{code}`.
+  ///
+  /// Retries up to 3 times on code collision (document already exists).
+  /// Throws [StateError] if all 3 attempts fail (should never happen in
+  /// practice given 729M possible codes).
+  @override
+  Future<String> create(String tripId, String createdBy) async {
+    const maxRetries = 3;
+
+    for (var attempt = 0; attempt < maxRetries; attempt++) {
+      final code = _generateCode();
+      final docRef = _invites.doc(code);
+
+      // Use a transaction to atomically check existence + write.
+      bool written = false;
+      await _firestore.runTransaction((tx) async {
+        final snapshot = await tx.get(docRef);
+        if (snapshot.exists) return; // collision — retry
+
+        final invite = Invite(
+          code: code,
+          tripId: tripId,
+          createdBy: createdBy,
+          createdAt: DateTime.now(),
+          active: true,
+        );
+        tx.set(docRef, invite.toFirestore());
+        written = true;
+      });
+
+      if (written) return code;
+    }
+
+    throw StateError(
+      'No se pudo generar un código de invitación único tras $maxRetries intentos.',
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Riverpod provider
+// ---------------------------------------------------------------------------
+
+/// Provides the [InviteRepository] implementation.
+///
+/// Returns the abstract [InviteRepository] type — callers never see
+/// [FirestoreInviteRepository]. To override in tests or dev mode:
+///
+/// ```dart
+/// ProviderScope(
+///   overrides: [
+///     inviteRepositoryProvider.overrideWithValue(MockInviteRepository()),
+///   ],
+///   child: MyApp(),
+/// )
+/// ```
+///
+/// Not autoDispose — the repository is stateless and cheap to keep alive.
+final inviteRepositoryProvider = Provider<InviteRepository>((ref) {
+  final firestore = ref.watch(firestoreProvider);
+  return FirestoreInviteRepository(firestore);
+});

--- a/app/lib/data/repositories/firestore_trip_repository.dart
+++ b/app/lib/data/repositories/firestore_trip_repository.dart
@@ -21,10 +21,6 @@ class FirestoreTripRepository implements TripRepository {
       _firestore.collection('trips');
 
   // ---------------------------------------------------------------------------
-  // Read
-  // ---------------------------------------------------------------------------
-
-  // ---------------------------------------------------------------------------
   // Write
   // ---------------------------------------------------------------------------
 
@@ -64,6 +60,17 @@ class FirestoreTripRepository implements TripRepository {
   // ---------------------------------------------------------------------------
   // Read
   // ---------------------------------------------------------------------------
+
+  /// Streams the single trip document at `trips/{tripId}`.
+  ///
+  /// Emits null if the document does not exist (e.g., was deleted).
+  @override
+  Stream<Trip?> watchById(String tripId) {
+    return _trips.doc(tripId).snapshots().map((snap) {
+      if (!snap.exists) return null;
+      return Trip.fromFirestore(snap);
+    });
+  }
 
   /// Streams all active trips the [userId] belongs to, ordered by [startDate].
   ///

--- a/app/lib/data/repositories/invite_repository.dart
+++ b/app/lib/data/repositories/invite_repository.dart
@@ -1,0 +1,12 @@
+/// Abstract contract for the invites data source.
+///
+/// The UI and notifiers depend on this type — never on the concrete Firestore
+/// implementation. See `app/CLAUDE.md` §"Dependencias y override pattern".
+abstract class InviteRepository {
+  /// Generates a unique 6-character invite code, writes the invite document
+  /// to `invites/{code}`, and returns the code on success.
+  ///
+  /// Retries up to 3 times on the (extremely unlikely) event of a code
+  /// collision in Firestore.
+  Future<String> create(String tripId, String createdBy);
+}

--- a/app/lib/data/repositories/trip_repository.dart
+++ b/app/lib/data/repositories/trip_repository.dart
@@ -23,4 +23,9 @@ abstract class TripRepository {
   /// The [facilitatorAlias] is used as the member alias for the facilitator.
   /// Returns the generated [tripId] on success.
   Future<String> create(Trip trip, String facilitatorAlias);
+
+  /// Streams the single trip document at `trips/{tripId}`.
+  ///
+  /// Emits null if the document does not exist (e.g., was deleted).
+  Stream<Trip?> watchById(String tripId);
 }

--- a/app/lib/dev/mocks/mock_trip_repository.dart
+++ b/app/lib/dev/mocks/mock_trip_repository.dart
@@ -48,4 +48,11 @@ class MockTripRepository implements TripRepository {
     _trips.add(trip.copyWith(id: fakeId));
     return fakeId;
   }
+
+  /// Returns a stream that emits the trip with [tripId] if it exists, or null.
+  @override
+  Stream<Trip?> watchById(String tripId) {
+    final trip = _trips.where((t) => t.id == tripId).firstOrNull;
+    return Stream.value(trip);
+  }
 }

--- a/app/lib/features/trips/application/generate_invite_notifier.dart
+++ b/app/lib/features/trips/application/generate_invite_notifier.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:vamos/data/repositories/firestore_invite_repository.dart';
-import 'package:vamos/features/auth/application/auth_notifier.dart';
+import 'package:vamos/features/trips/application/my_trips_notifier.dart';
 
 // ---------------------------------------------------------------------------
 // Notifier

--- a/app/lib/features/trips/application/generate_invite_notifier.dart
+++ b/app/lib/features/trips/application/generate_invite_notifier.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vamos/data/repositories/firestore_invite_repository.dart';
+import 'package:vamos/features/auth/application/auth_notifier.dart';
+
+// ---------------------------------------------------------------------------
+// Notifier
+// ---------------------------------------------------------------------------
+
+/// Handles the invite-code generation triggered from the success screen (F1.3).
+///
+/// State is `String?`:
+///   - null   → no code generated yet (idle)
+///   - String → the 6-char code returned by [InviteRepository.create]
+///
+/// autoDispose: scoped to the InviteScreen lifecycle; released on pop.
+/// family: keyed by [tripId] so the code is tied to a specific trip.
+class GenerateInviteNotifier
+    extends AutoDisposeFamilyAsyncNotifier<String?, String> {
+  @override
+  Future<String?> build(String tripId) async {
+    // Eagerly generate the code when the screen mounts.
+    return _generate(tripId);
+  }
+
+  Future<String?> _generate(String tripId) async {
+    final userId = ref.read(currentUserIdProvider);
+    if (userId.isEmpty) throw StateError('No hay un usuario autenticado.');
+
+    final code =
+        await ref.read(inviteRepositoryProvider).create(tripId, userId);
+    return code;
+  }
+
+  /// Allows the screen to retry if an error occurred.
+  Future<void> retry() async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() => _generate(arg));
+  }
+}
+
+/// Riverpod provider for [GenerateInviteNotifier].
+///
+/// Keyed by [tripId] — the notifier auto-generates the invite on first build.
+final generateInviteProvider = AsyncNotifierProvider.autoDispose
+    .family<GenerateInviteNotifier, String?, String>(
+  GenerateInviteNotifier.new,
+);

--- a/app/lib/features/trips/presentation/create_trip_screen.dart
+++ b/app/lib/features/trips/presentation/create_trip_screen.dart
@@ -114,7 +114,8 @@ class _CreateTripScreenState extends ConsumerState<CreateTripScreen> {
       next.whenData((result) {
         if (result.tripId != null) {
           _hasNavigated = true;
-          context.go('/trips/${result.tripId}');
+          // Navigate to F1.3 (invite screen) instead of the trip stub.
+          context.go('/trips/${result.tripId}/invite');
         }
       });
     });

--- a/app/lib/features/trips/presentation/invite_screen.dart
+++ b/app/lib/features/trips/presentation/invite_screen.dart
@@ -1,0 +1,430 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:vamos/core/theme/vamos_colors.dart';
+import 'package:vamos/core/theme/vamos_spacing.dart';
+import 'package:vamos/core/theme/vamos_typography.dart';
+import 'package:vamos/data/models/trip.dart';
+import 'package:vamos/data/repositories/firestore_trip_repository.dart';
+import 'package:vamos/features/trips/application/generate_invite_notifier.dart';
+
+/// F1.3 — "Tu viaje está listo" — invite-link screen.
+///
+/// Shows the trip name + dates, the generated short link, and three
+/// sharing actions: copy to clipboard, WhatsApp, native share sheet.
+/// Also surfaces a primary CTA to proceed to the trip detail.
+///
+/// The invite code is generated on first mount via [GenerateInviteNotifier].
+/// The screen handles loading, error, and data states.
+class InviteScreen extends ConsumerWidget {
+  const InviteScreen({super.key, required this.tripId});
+
+  final String tripId;
+
+  static const String _baseUrl = 'vamos.app/j';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final tripAsync = ref.watch(_tripProvider(tripId));
+    final inviteAsync = ref.watch(generateInviteProvider(tripId));
+
+    return Scaffold(
+      // No back button — the create-trip form is consumed; popping back would
+      // be confusing. The user proceeds via "Ir al viaje".
+      appBar: AppBar(
+        automaticallyImplyLeading: false,
+        title: const Text('Viaje creado'),
+      ),
+      body: SafeArea(
+        child: tripAsync.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (err, _) => _ErrorState(
+            message: 'No se pudo cargar el viaje.',
+            onRetry: () => ref.invalidate(_tripProvider(tripId)),
+          ),
+          data: (trip) {
+            if (trip == null) {
+              return _ErrorState(
+                message: 'El viaje no existe.',
+                onRetry: () => ref.invalidate(_tripProvider(tripId)),
+              );
+            }
+            return _Content(
+              tripId: tripId,
+              trip: trip,
+              inviteAsync: inviteAsync,
+              onRetryInvite: () =>
+                  ref.read(generateInviteProvider(tripId).notifier).retry(),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main content — rendered once the trip is loaded
+// ---------------------------------------------------------------------------
+
+class _Content extends StatelessWidget {
+  const _Content({
+    required this.tripId,
+    required this.trip,
+    required this.inviteAsync,
+    required this.onRetryInvite,
+  });
+
+  final String tripId;
+  final Trip trip;
+  final AsyncValue<String?> inviteAsync;
+  final VoidCallback onRetryInvite;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(
+        horizontal: VamosSpacing.md,
+        vertical: VamosSpacing.lg,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // ── Success icon ──────────────────────────────────────────────────
+          const _SuccessIcon(),
+          const SizedBox(height: VamosSpacing.lg),
+
+          // ── Title (validated microcopy §5.2) ─────────────────────────────
+          Text(
+            'Tu viaje está listo',
+            style: VamosTypography.displayMedium,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: VamosSpacing.sm),
+
+          // ── Trip summary ──────────────────────────────────────────────────
+          Text(
+            trip.name,
+            style: VamosTypography.headlineMedium,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: VamosSpacing.xs),
+          Text(
+            _formatDateRange(trip.startDate, trip.endDate),
+            style: VamosTypography.monoMedium.copyWith(
+              color: VamosColors.text3,
+            ),
+            textAlign: TextAlign.center,
+          ),
+
+          const SizedBox(height: VamosSpacing.xxl),
+
+          // ── Divider + share section ───────────────────────────────────────
+          const Divider(height: 1),
+          const SizedBox(height: VamosSpacing.lg),
+
+          Text(
+            'Compartí este link con el grupo. Quien lo abra, entra.',
+            style: VamosTypography.bodyMedium,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: VamosSpacing.md),
+
+          // ── Invite link chip (loading / error / data) ─────────────────────
+          inviteAsync.when(
+            loading: () => const _LinkSkeleton(),
+            error: (err, _) => _LinkError(onRetry: onRetryInvite),
+            data: (code) {
+              if (code == null) return _LinkError(onRetry: onRetryInvite);
+              final link = '${InviteScreen._baseUrl}/$code';
+              return _LinkChip(link: link, code: code);
+            },
+          ),
+
+          const SizedBox(height: VamosSpacing.md),
+
+          // ── WhatsApp button ───────────────────────────────────────────────
+          inviteAsync.whenData((code) {
+            if (code == null) return const SizedBox.shrink();
+            return _WhatsAppButton(code: code);
+          }).value ??
+              const SizedBox.shrink(),
+
+          const SizedBox(height: VamosSpacing.sm),
+
+          // ── Native share button ───────────────────────────────────────────
+          inviteAsync.whenData((code) {
+            if (code == null) return const SizedBox.shrink();
+            return _NativeShareButton(code: code);
+          }).value ??
+              const SizedBox.shrink(),
+
+          const SizedBox(height: VamosSpacing.xxl),
+
+          // ── Primary CTA ───────────────────────────────────────────────────
+          FilledButton(
+            onPressed: () => context.go('/trips/$tripId'),
+            child: const Text('Ir al viaje'),
+          ),
+
+          const SizedBox(height: VamosSpacing.lg),
+        ],
+      ),
+    );
+  }
+
+  String _formatDateRange(DateTime start, DateTime end) {
+    final fmt = DateFormat('d MMM yyyy', 'es');
+    return '${fmt.format(start)} – ${fmt.format(end)}';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-widgets
+// ---------------------------------------------------------------------------
+
+class _SuccessIcon extends StatelessWidget {
+  const _SuccessIcon();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: VamosSpacing.xxxl,
+      height: VamosSpacing.xxxl,
+      decoration: const BoxDecoration(
+        color: VamosColors.green,
+        shape: BoxShape.circle,
+      ),
+      alignment: Alignment.center,
+      child: const Icon(
+        Icons.check,
+        color: VamosColors.textOnDark,
+        size: VamosSpacing.xl,
+      ),
+    );
+  }
+}
+
+/// Displayed while the invite code is being generated in Firestore.
+class _LinkSkeleton extends StatelessWidget {
+  const _LinkSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: VamosSpacing.md,
+        vertical: VamosSpacing.md,
+      ),
+      decoration: BoxDecoration(
+        color: VamosColors.surface2,
+        borderRadius: VamosRadius.brLg,
+        border: Border.all(color: VamosColors.border),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              'Generando link…',
+              style: VamosTypography.monoMedium.copyWith(
+                color: VamosColors.textMuted,
+              ),
+            ),
+          ),
+          const SizedBox(
+            width: VamosSpacing.md,
+            height: VamosSpacing.md,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Displayed when invite generation fails.
+class _LinkError extends StatelessWidget {
+  const _LinkError({required this.onRetry});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(VamosSpacing.md),
+      decoration: BoxDecoration(
+        color: VamosColors.red.withValues(alpha: 0.08),
+        borderRadius: VamosRadius.brLg,
+        border: Border.all(color: VamosColors.red.withValues(alpha: 0.3)),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.error_outline, color: VamosColors.red, size: VamosSpacing.md),
+          const SizedBox(width: VamosSpacing.sm),
+          Expanded(
+            child: Text(
+              'No se pudo generar el link.',
+              style: VamosTypography.bodyMedium.copyWith(color: VamosColors.red),
+            ),
+          ),
+          TextButton(
+            onPressed: onRetry,
+            child: const Text('Reintentar'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The invite link chip with the copy button.
+class _LinkChip extends StatelessWidget {
+  const _LinkChip({required this.link, required this.code});
+
+  final String link;
+  final String code;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: VamosColors.surface,
+        borderRadius: VamosRadius.brLg,
+        border: Border.all(color: VamosColors.border),
+      ),
+      child: Row(
+        children: [
+          // Link text
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: VamosSpacing.md,
+                vertical: VamosSpacing.md,
+              ),
+              child: Text(
+                link,
+                style: VamosTypography.monoMedium,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ),
+          // Copy button
+          IconButton(
+            icon: const Icon(Icons.copy_outlined),
+            tooltip: 'Copiar link',
+            onPressed: () => _copyToClipboard(context, link),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _copyToClipboard(BuildContext context, String text) {
+    Clipboard.setData(ClipboardData(text: text));
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('Link copiado'),
+        duration: Duration(seconds: 2),
+      ),
+    );
+  }
+}
+
+/// WhatsApp share button — opens the wa.me share URL with the link pre-filled.
+class _WhatsAppButton extends StatelessWidget {
+  const _WhatsAppButton({required this.code});
+
+  final String code;
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlinedButton.icon(
+      onPressed: () => _shareWhatsApp(context, code),
+      icon: const Icon(Icons.chat_outlined),
+      label: const Text('Compartir por WhatsApp'),
+    );
+  }
+
+  Future<void> _shareWhatsApp(BuildContext context, String code) async {
+    final link = 'vamos.app/j/$code';
+    final message = Uri.encodeComponent(
+      'Sumate al viaje en Vamos: https://$link',
+    );
+    final uri = Uri.parse('https://wa.me/?text=$message');
+
+    if (!await launchUrl(uri, mode: LaunchMode.externalApplication)) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('No se pudo abrir WhatsApp.'),
+          ),
+        );
+      }
+    }
+  }
+}
+
+/// Native share sheet button using share_plus.
+class _NativeShareButton extends StatelessWidget {
+  const _NativeShareButton({required this.code});
+
+  final String code;
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlinedButton.icon(
+      onPressed: () => _shareNative(code),
+      icon: const Icon(Icons.ios_share_outlined),
+      label: const Text('Compartir por otro lado'),
+    );
+  }
+
+  Future<void> _shareNative(String code) async {
+    final link = 'https://vamos.app/j/$code';
+    await Share.share('Sumate al viaje en Vamos: $link');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error state for the whole screen (trip not found / load error)
+// ---------------------------------------------------------------------------
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(VamosSpacing.lg),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(message, style: VamosTypography.bodyLarge, textAlign: TextAlign.center),
+          const SizedBox(height: VamosSpacing.md),
+          FilledButton(
+            onPressed: onRetry,
+            child: const Text('Reintentar'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private trip stream provider (scoped to this file)
+// ---------------------------------------------------------------------------
+
+/// Watches a single trip document — scoped to [InviteScreen].
+/// autoDispose + family so it is released when the screen pops.
+final _tripProvider = StreamProvider.autoDispose
+    .family<Trip?, String>((ref, tripId) {
+  return ref.watch(tripRepositoryProvider).watchById(tripId);
+});

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -56,6 +56,10 @@ dependencies:
   # Date and number formatting (NOT internationalization — Spanish hardcoded)
   intl: ^0.20.2
 
+  # Sharing + deep-link opening
+  share_plus: ^10.1.4
+  url_launcher: ^6.3.1
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary

- `data/models/invite.dart` — Invite model
- `data/repositories/invite_repository.dart` + `firestore_invite_repository.dart` — 6-char code generation (base32 no-ambiguous charset, 3-retry collision handling)
- `features/trips/application/generate_invite_notifier.dart` — AsyncNotifier eagerly generating invite on build
- `features/trips/presentation/invite_screen.dart` — F1.3 with copy, WhatsApp deep link, native share, navigate to trip
- `share_plus ^10.1.4` + `url_launcher ^6.3.1` added
- `trip_repository.dart` — `watchById()` added
- Router: `/trips/:id/invite` wired; CreateTripScreen now navigates here on success

## Issue

Closes #11

## Checklist

- [x] Invite model + repository
- [x] 6-char code with collision retry
- [x] GenerateInviteNotifier
- [x] InviteScreen (F1.3)
- [x] Copy / WhatsApp / native share
- [x] Router wired
- [x] flutter analyze: zero new warnings