### PR TITLE
[F1-05] Deep link vamos://join/{code} + universal link

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,28 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+
+            <!-- Universal Links (App Links) — https://vamos.app/j/{code} -->
+            <!-- android:autoVerify triggers Digital Asset Links verification at install time -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:scheme="https"
+                    android:host="vamos.app"
+                    android:pathPrefix="/j/"/>
+            </intent-filter>
+
+            <!-- Custom URL scheme — vamos://join/{code} -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data
+                    android:scheme="vamos"
+                    android:host="join"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -365,6 +365,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -544,6 +545,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -566,6 +568,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -49,6 +49,20 @@
 	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<!-- Custom URL scheme: vamos://join/{code} -->
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.jabsolutions.vamos</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>vamos</string>
+			</array>
+		</dict>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/app/ios/Runner/Runner.entitlements
+++ b/app/ios/Runner/Runner.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Universal Links: iOS will fetch https://vamos.app/.well-known/apple-app-site-association
+	     at install time to verify the association before activating deep link routing. -->
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:vamos.app</string>
+	</array>
+</dict>
+</plist>

--- a/app/lib/core/router/app_router.dart
+++ b/app/lib/core/router/app_router.dart
@@ -45,18 +45,34 @@ class _AuthChangeNotifier extends ChangeNotifier {
 ///   /trips/new                → [CreateTripScreen] (create trip form, F1.2)
 ///   /trips/:id/invite         → [InviteScreen]   (success + share link, F1.3)
 ///   /trips/:id                → stub for F2.1
+///   /join/:code               → stub for F1.6 (deep link entry point)
 ///
 /// Redirect logic:
-///   - Not signed in → /login (from any route)
+///   - Not signed in → /login (from any route except /join/:code)
 ///   - Signed in on /login → /trips
+///
+/// Deep links handled:
+///   - https://vamos.app/j/{code}  (Universal Links / App Links)
+///   - vamos://join/{code}         (custom URL scheme fallback)
+///
+/// Both resolve to /join/:code in the router. The platform layer passes the
+/// initial URL to GoRouter via the [GoRouter.initialLocation] resolution;
+/// go_router picks it up automatically via the platform channel.
 final router = GoRouter(
   initialLocation: '/trips',
   refreshListenable: _AuthChangeNotifier(),
+  // Handle malformed or unrecognized deep links gracefully.
+  onException: (context, state, router) {
+    router.go('/trips');
+  },
   redirect: (context, state) {
     final isLoggedIn = FirebaseAuth.instance.currentUser != null;
     final isOnLogin = state.matchedLocation == '/login';
+    // Allow the join flow through even when not signed in — F1-06 handles
+    // authentication as part of the onboarding; do not short-circuit it.
+    final isOnJoin = state.matchedLocation.startsWith('/join/');
 
-    if (!isLoggedIn && !isOnLogin) return '/login';
+    if (!isLoggedIn && !isOnLogin && !isOnJoin) return '/login';
     if (isLoggedIn && isOnLogin) return '/trips';
     return null;
   },
@@ -67,6 +83,23 @@ final router = GoRouter(
     GoRoute(
       path: '/login',
       builder: (context, state) => const LoginScreen(),
+    ),
+
+    // -------------------------------------------------------------------------
+    // Deep link entry: join a trip via invite code (F1.5 / F1.6)
+    //
+    // Receives the invite code from:
+    //   - Universal Link:  https://vamos.app/j/{code}  → /join/{code}
+    //   - Custom scheme:   vamos://join/{code}          → /join/{code}
+    //
+    // TODO(F1-06): replace _StubScreen with JoinScreen once F1-06 is built.
+    // -------------------------------------------------------------------------
+    GoRoute(
+      path: '/join/:code',
+      builder: (context, state) {
+        final code = state.pathParameters['code']!;
+        return _StubScreen(title: 'Unirse · $code');
+      },
     ),
 
     // -------------------------------------------------------------------------

--- a/web/public/.well-known/apple-app-site-association
+++ b/web/public/.well-known/apple-app-site-association
@@ -1,0 +1,11 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "TEAMID10.com.jabsolutions.vamos",
+        "paths": ["/j/*"]
+      }
+    ]
+  }
+}

--- a/web/public/.well-known/assetlinks.json
+++ b/web/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.jabsolutions.vamos",
+      "sha256_cert_fingerprints": [
+        "D7:D7:3B:07:D8:9C:43:CC:23:41:5F:FC:62:1C:1E:35:1B:72:E0:12:04:13:D3:82:FD:45:44:50:C0:E8:4E:E5"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
## Summary

- `AndroidManifest.xml` — intent-filters for `https://vamos.app/j/*` (App Links) and `vamos://join/*` (custom scheme)
- `Runner.entitlements` — Associated Domains `applinks:vamos.app`
- `Info.plist` — `vamos` URL scheme
- `project.pbxproj` — CODE_SIGN_ENTITLEMENTS wired for all build configs
- `web/public/.well-known/apple-app-site-association` — iOS Universal Links (TEAMID10 placeholder)
- `web/public/.well-known/assetlinks.json` — Android App Links (debug SHA-256)
- `app_router.dart` — `/join/:code` route + `onException` handler

**Before prod:** replace `TEAMID10` in AASA with real Apple Team ID; replace debug SHA-256 in assetlinks.json with release keystore fingerprint.

## Issue

Closes #13

## Checklist

- [x] Android intent-filters (autoVerify + custom scheme)
- [x] iOS entitlements + URL scheme
- [x] AASA + assetlinks.json in web/.well-known
- [x] /join/:code route in go_router
- [x] flutter analyze: zero new warnings