### PR TITLE
[F1-06] Onboarding del miembro al unirse (F1.4-F1.5)

### DIFF
--- a/app/lib/core/router/app_router.dart
+++ b/app/lib/core/router/app_router.dart
@@ -4,6 +4,10 @@ import 'package:go_router/go_router.dart';
 import 'package:vamos/features/auth/presentation/login_screen.dart';
 import 'package:vamos/features/trips/presentation/create_trip_screen.dart';
 import 'package:vamos/features/trips/presentation/invite_screen.dart';
+import 'package:vamos/features/trips/presentation/join_alias_screen.dart';
+import 'package:vamos/features/trips/presentation/join_entry_screen.dart';
+import 'package:vamos/features/trips/presentation/join_profile_screen.dart';
+import 'package:vamos/features/trips/presentation/join_tags_screen.dart';
 import 'package:vamos/features/trips/presentation/my_trips_screen.dart';
 
 // ---------------------------------------------------------------------------
@@ -86,20 +90,72 @@ final router = GoRouter(
     ),
 
     // -------------------------------------------------------------------------
-    // Deep link entry: join a trip via invite code (F1.5 / F1.6)
+    // Deep link entry: join a trip via invite code (F1.4 / F1.4b / F1.5)
     //
     // Receives the invite code from:
     //   - Universal Link:  https://vamos.app/j/{code}  → /join/{code}
     //   - Custom scheme:   vamos://join/{code}          → /join/{code}
     //
-    // TODO(F1-06): replace _StubScreen with JoinScreen once F1-06 is built.
+    // /join/:code          → JoinEntryScreen (resolves invite → profile check)
+    // /join/:code/profile  → JoinProfileScreen (F1.4, new users only)
+    // /join/:code/alias    → JoinAliasScreen   (F1.4b, all users)
+    // /join/:code/tags     → JoinTagsScreen    (F1.5, all users)
     // -------------------------------------------------------------------------
     GoRoute(
       path: '/join/:code',
       builder: (context, state) {
         final code = state.pathParameters['code']!;
-        return _StubScreen(title: 'Unirse · $code');
+        return JoinEntryScreen(inviteCode: code);
       },
+      routes: [
+        // F1.4 — Profile setup (new users only)
+        GoRoute(
+          path: 'profile',
+          builder: (context, state) {
+            final code = state.pathParameters['code']!;
+            final extra = state.extra as Map<String, dynamic>? ?? {};
+            final tripId = extra['tripId'] as String? ?? '';
+            final defaultName = extra['defaultName'] as String? ?? '';
+            return JoinProfileScreen(
+              inviteCode: code,
+              tripId: tripId,
+              defaultName: defaultName,
+            );
+          },
+        ),
+        // F1.4b — Alias selection (all users)
+        GoRoute(
+          path: 'alias',
+          builder: (context, state) {
+            final code = state.pathParameters['code']!;
+            final extra = state.extra as Map<String, dynamic>? ?? {};
+            final tripId = extra['tripId'] as String? ?? '';
+            final isNewUser = extra['isNewUser'] as bool? ?? false;
+            final defaultName = extra['defaultName'] as String? ?? '';
+            return JoinAliasScreen(
+              inviteCode: code,
+              tripId: tripId,
+              isNewUser: isNewUser,
+              defaultName: defaultName,
+            );
+          },
+        ),
+        // F1.5 — Preference tags (all users)
+        GoRoute(
+          path: 'tags',
+          builder: (context, state) {
+            final code = state.pathParameters['code']!;
+            final extra = state.extra as Map<String, dynamic>? ?? {};
+            final tripId = extra['tripId'] as String? ?? '';
+            final isNewUser = extra['isNewUser'] as bool? ?? false;
+            return JoinTagsScreen(
+              inviteCode: code,
+              tripId: tripId,
+              isNewUser: isNewUser,
+            );
+          },
+        ),
+      ],
     ),
 
     // -------------------------------------------------------------------------

--- a/app/lib/data/repositories/firestore_invite_repository.dart
+++ b/app/lib/data/repositories/firestore_invite_repository.dart
@@ -45,6 +45,25 @@ class FirestoreInviteRepository implements InviteRepository {
   /// Retries up to 3 times on code collision (document already exists).
   /// Throws [StateError] if all 3 attempts fail (should never happen in
   /// practice given 729M possible codes).
+  // ---------------------------------------------------------------------------
+  // Read
+  // ---------------------------------------------------------------------------
+
+  /// Reads `invites/{code}` and returns the trip ID, or null if missing/inactive.
+  @override
+  Future<String?> getTripId(String code) async {
+    final snap = await _invites.doc(code).get();
+    if (!snap.exists) return null;
+    final data = snap.data()!;
+    final isActive = data['active'] as bool? ?? false;
+    if (!isActive) return null;
+    return data['tripId'] as String?;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Write
+  // ---------------------------------------------------------------------------
+
   @override
   Future<String> create(String tripId, String createdBy) async {
     const maxRetries = 3;

--- a/app/lib/data/repositories/firestore_member_repository.dart
+++ b/app/lib/data/repositories/firestore_member_repository.dart
@@ -7,9 +7,10 @@ import 'package:vamos/data/repositories/member_repository.dart';
 /// Firestore implementation of [MemberRepository].
 ///
 /// This is the ONLY file in the app that imports `cloud_firestore` for members.
-/// Skeleton: methods throw [UnimplementedError] until F1.x implements the
-/// members flow. The interface is in place so that other repos and notifiers
-/// can depend on [MemberRepository] without coupling to Firebase.
+/// Widgets, notifiers, and tests never reference this class directly — they
+/// depend on the [MemberRepository] abstract type via [memberRepositoryProvider].
+///
+/// See `app/CLAUDE.md` §Hard rules — rule 1.
 class FirestoreMemberRepository implements MemberRepository {
   const FirestoreMemberRepository(this._firestore);
 
@@ -18,10 +19,33 @@ class FirestoreMemberRepository implements MemberRepository {
   CollectionReference<Map<String, dynamic>> _members(String tripId) =>
       _firestore.collection('trips').doc(tripId).collection('members');
 
+  DocumentReference<Map<String, dynamic>> _trip(String tripId) =>
+      _firestore.collection('trips').doc(tripId);
+
+  DocumentReference<Map<String, dynamic>> _invite(String code) =>
+      _firestore.collection('invites').doc(code);
+
+  // ---------------------------------------------------------------------------
+  // Read
+  // ---------------------------------------------------------------------------
+
   @override
-  Stream<List<Member>> watchTripMembers(String tripId) {
-    // TODO(F1-x): implement when the members flow is built.
-    throw UnimplementedError('watchTripMembers is not yet implemented');
+  Stream<List<Member>> watchTripMembers(String tripId) =>
+      watchByTrip(tripId);
+
+  @override
+  Stream<List<Member>> watchByTrip(String tripId) {
+    return _members(tripId).snapshots().map((snap) {
+      return snap.docs.map((doc) {
+        final data = doc.data();
+        return Member(
+          userId: doc.id,
+          alias: data['alias'] as String,
+          tags: Map<String, dynamic>.from(data['tags'] as Map? ?? {}),
+          joinedAt: (data['joinedAt'] as Timestamp).toDate(),
+        );
+      }).toList();
+    });
   }
 
   @override
@@ -29,8 +53,57 @@ class FirestoreMemberRepository implements MemberRepository {
     required String tripId,
     required String userId,
   }) async {
-    // TODO(F1-x): implement when the members flow is built.
-    throw UnimplementedError('getMember is not yet implemented');
+    final snap = await _members(tripId).doc(userId).get();
+    if (!snap.exists) return null;
+    final data = snap.data()!;
+    return Member(
+      userId: snap.id,
+      alias: data['alias'] as String,
+      tags: Map<String, dynamic>.from(data['tags'] as Map? ?? {}),
+      joinedAt: (data['joinedAt'] as Timestamp).toDate(),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Write
+  // ---------------------------------------------------------------------------
+
+  /// Validates [inviteCode] and atomically registers [member] in the trip.
+  ///
+  /// Pre-check (outside transaction): reads `invites/{inviteCode}` to verify
+  /// `active == true`. This is done outside the transaction deliberately — it
+  /// is a read-only guard and Firestore transactions have limited read capacity.
+  ///
+  /// Transaction (atomic):
+  ///   - `arrayUnion` [member.userId] into `trips/{tripId}.memberIds`
+  ///   - Write `trips/{tripId}/members/{member.userId}` with alias, tags,
+  ///     joinedAt
+  ///
+  /// Throws [InviteLinkInactiveException] if the invite is inactive or missing.
+  @override
+  Future<void> joinTrip({
+    required String tripId,
+    required String inviteCode,
+    required Member member,
+  }) async {
+    // Step 1 — validate invite (outside transaction, read-only guard).
+    final inviteSnap = await _invite(inviteCode).get();
+    if (!inviteSnap.exists) throw const InviteLinkInactiveException();
+    final isActive = inviteSnap.data()?['active'] as bool? ?? false;
+    if (!isActive) throw const InviteLinkInactiveException();
+
+    // Step 2 — atomic write: memberIds arrayUnion + member doc.
+    await _firestore.runTransaction((tx) async {
+      final tripRef = _trip(tripId);
+      final memberRef = _members(tripId).doc(member.userId);
+
+      // arrayUnion is safe even if the uid is already present (idempotent).
+      tx.update(tripRef, {
+        'memberIds': FieldValue.arrayUnion([member.userId]),
+      });
+
+      tx.set(memberRef, member.toFirestore());
+    });
   }
 }
 

--- a/app/lib/data/repositories/firestore_user_repository.dart
+++ b/app/lib/data/repositories/firestore_user_repository.dart
@@ -1,0 +1,81 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vamos/data/firebase/firebase_providers.dart';
+import 'package:vamos/data/repositories/user_repository.dart';
+
+/// Firestore implementation of [UserRepository].
+///
+/// This is the ONLY file in the app that imports `cloud_firestore` for users.
+/// Widgets, notifiers, and tests never reference this class directly — they
+/// depend on the [UserRepository] abstract type via [userRepositoryProvider].
+///
+/// See `app/CLAUDE.md` §Hard rules — rule 1.
+class FirestoreUserRepository implements UserRepository {
+  const FirestoreUserRepository(this._firestore);
+
+  final FirebaseFirestore _firestore;
+
+  CollectionReference<Map<String, dynamic>> get _users =>
+      _firestore.collection('users');
+
+  // ---------------------------------------------------------------------------
+  // Read
+  // ---------------------------------------------------------------------------
+
+  /// Returns true if the `users/{userId}` document exists in Firestore.
+  ///
+  /// A single document get is used instead of a stream — this is a one-shot
+  /// check during onboarding, not a live listener.
+  @override
+  Future<bool> profileExists(String userId) async {
+    final snap = await _users.doc(userId).get();
+    return snap.exists;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Write
+  // ---------------------------------------------------------------------------
+
+  /// Creates or overwrites the `users/{userId}` document.
+  ///
+  /// Uses [SetOptions.merge] so that a concurrent call (e.g., from a retry)
+  /// does not wipe out future fields added by later schema versions.
+  @override
+  Future<void> saveProfile({
+    required String userId,
+    required String displayName,
+    String? photoURL,
+  }) async {
+    final data = <String, dynamic>{
+      'displayName': displayName,
+      'updatedAt': FieldValue.serverTimestamp(),
+    };
+    if (photoURL != null) data['photoURL'] = photoURL;
+
+    await _users.doc(userId).set(data, SetOptions(merge: true));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Riverpod provider
+// ---------------------------------------------------------------------------
+
+/// Provides the [UserRepository] implementation.
+///
+/// Returns the abstract [UserRepository] type — callers never see
+/// [FirestoreUserRepository]. To override in tests or dev mode:
+///
+/// ```dart
+/// ProviderScope(
+///   overrides: [
+///     userRepositoryProvider.overrideWithValue(MockUserRepository()),
+///   ],
+///   child: MyApp(),
+/// )
+/// ```
+///
+/// Not autoDispose — the repository is stateless and cheap to keep alive.
+final userRepositoryProvider = Provider<UserRepository>((ref) {
+  final firestore = ref.watch(firestoreProvider);
+  return FirestoreUserRepository(firestore);
+});

--- a/app/lib/data/repositories/invite_repository.dart
+++ b/app/lib/data/repositories/invite_repository.dart
@@ -9,4 +9,11 @@ abstract class InviteRepository {
   /// Retries up to 3 times on the (extremely unlikely) event of a code
   /// collision in Firestore.
   Future<String> create(String tripId, String createdBy);
+
+  /// Reads `invites/{code}` and returns the associated [tripId], or null if
+  /// the document does not exist or is inactive (`active == false`).
+  ///
+  /// Used by [JoinEntryScreen] to resolve the invite code from the deep link
+  /// into the Firestore trip ID before starting the onboarding flow.
+  Future<String?> getTripId(String code);
 }

--- a/app/lib/data/repositories/member_repository.dart
+++ b/app/lib/data/repositories/member_repository.dart
@@ -9,7 +9,38 @@ abstract class MemberRepository {
   /// Streams all members of the trip identified by [tripId].
   Stream<List<Member>> watchTripMembers(String tripId);
 
+  /// Alias for [watchTripMembers] — used by onboarding screens to confirm
+  /// the new member appears in the live list after joining.
+  Stream<List<Member>> watchByTrip(String tripId);
+
   /// Returns the member document for [userId] inside [tripId], or null if
   /// the user is not a member.
   Future<Member?> getMember({required String tripId, required String userId});
+
+  /// Validates the invite code and atomically adds the user as a member.
+  ///
+  /// Steps:
+  ///   1. Read `invites/{inviteCode}` — throws [InviteLinkInactiveException]
+  ///      if `active != true`.
+  ///   2. In a single Firestore transaction:
+  ///      - `arrayUnion` [member.userId] into `trips/{tripId}.memberIds`
+  ///      - Write `trips/{tripId}/members/{member.userId}` with alias, tags,
+  ///        joinedAt.
+  ///
+  /// The [tripId] must match the one stored in the invite document; it is read
+  /// from Firestore to avoid trusting a client-provided value.
+  Future<void> joinTrip({
+    required String tripId,
+    required String inviteCode,
+    required Member member,
+  });
+}
+
+/// Thrown when an invite link is no longer active (revoked by facilitator
+/// or already used by a different flow).
+class InviteLinkInactiveException implements Exception {
+  const InviteLinkInactiveException();
+
+  @override
+  String toString() => 'InviteLinkInactiveException: el link ya no está activo';
 }

--- a/app/lib/data/repositories/user_repository.dart
+++ b/app/lib/data/repositories/user_repository.dart
@@ -1,0 +1,22 @@
+/// Abstract contract for the users data source.
+///
+/// The UI and notifiers depend on this type — never on the concrete Firestore
+/// implementation. See `app/CLAUDE.md` §"Dependencias y override pattern".
+abstract class UserRepository {
+  /// Returns true if the `users/{userId}` document already exists in Firestore.
+  ///
+  /// Used during onboarding (F1.4) to decide whether to show the profile-setup
+  /// screen (new user) or skip directly to the alias screen (returning user).
+  Future<bool> profileExists(String userId);
+
+  /// Creates or overwrites the `users/{userId}` document with the provided
+  /// display name (and optional photo URL).
+  ///
+  /// Called once when a new user completes the profile step (F1.4). Safe to
+  /// call multiple times — it is a set (not an update), so it is idempotent.
+  Future<void> saveProfile({
+    required String userId,
+    required String displayName,
+    String? photoURL,
+  });
+}

--- a/app/lib/features/trips/application/join_trip_notifier.dart
+++ b/app/lib/features/trips/application/join_trip_notifier.dart
@@ -1,0 +1,167 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vamos/data/models/member.dart';
+import 'package:vamos/data/repositories/firestore_member_repository.dart';
+import 'package:vamos/data/repositories/firestore_user_repository.dart';
+import 'package:vamos/data/repositories/member_repository.dart';
+import 'package:vamos/data/repositories/user_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Transient onboarding state — held in the notifier during the 3-screen flow.
+// ---------------------------------------------------------------------------
+
+/// Mutable state accumulated across the 3 onboarding screens (F1.4 → F1.4b
+/// → F1.5) before the final `submitOnboarding` write.
+class JoinOnboardingState {
+  const JoinOnboardingState({
+    this.displayName = '',
+    this.alias = '',
+    this.dietTags = const [],
+    this.paceTags = const [],
+    this.budget = '',
+  });
+
+  /// Global profile name (collected in F1.4 for new users).
+  final String displayName;
+
+  /// Trip-specific alias (collected in F1.4b for all users).
+  final String alias;
+
+  /// Multi-select diet restrictions (F1.5).
+  final List<String> dietTags;
+
+  /// Multi-select pace preferences (F1.5).
+  final List<String> paceTags;
+
+  /// Single-select budget preference — empty string if not selected (F1.5).
+  final String budget;
+
+  JoinOnboardingState copyWith({
+    String? displayName,
+    String? alias,
+    List<String>? dietTags,
+    List<String>? paceTags,
+    String? budget,
+  }) {
+    return JoinOnboardingState(
+      displayName: displayName ?? this.displayName,
+      alias: alias ?? this.alias,
+      dietTags: dietTags ?? this.dietTags,
+      paceTags: paceTags ?? this.paceTags,
+      budget: budget ?? this.budget,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Notifier
+// ---------------------------------------------------------------------------
+
+/// Manages the join-trip onboarding flow (F1.4 → F1.4b → F1.5).
+///
+/// Family param is the [inviteCode] from the deep link — it is fixed for the
+/// duration of the onboarding and is used in [submitOnboarding].
+///
+/// State lifecycle:
+///   - `AsyncData(null)` — idle (flow in progress, no write yet).
+///   - `AsyncLoading()` — [submitOnboarding] in flight.
+///   - `AsyncData(null)` — write completed successfully.
+///   - `AsyncError(e, _)` — write failed (shows error in UI).
+class JoinTripNotifier
+    extends AutoDisposeFamilyAsyncNotifier<void, String> {
+  @override
+  Future<void> build(String inviteCode) async {
+    // No initial side effect — the notifier starts idle.
+  }
+
+  // Transient state accumulated across screens.
+  JoinOnboardingState _onboarding = const JoinOnboardingState();
+
+  JoinOnboardingState get onboarding => _onboarding;
+
+  // ---------------------------------------------------------------------------
+  // Setters called by each screen as the user advances
+  // ---------------------------------------------------------------------------
+
+  void setDisplayName(String name) {
+    _onboarding = _onboarding.copyWith(displayName: name);
+  }
+
+  void setAlias(String alias) {
+    _onboarding = _onboarding.copyWith(alias: alias);
+  }
+
+  void setDietTags(List<String> tags) {
+    _onboarding = _onboarding.copyWith(dietTags: tags);
+  }
+
+  void setPaceTags(List<String> tags) {
+    _onboarding = _onboarding.copyWith(paceTags: tags);
+  }
+
+  void setBudget(String budget) {
+    _onboarding = _onboarding.copyWith(budget: budget);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Submit (called from JoinTagsScreen on "Entrar al viaje")
+  // ---------------------------------------------------------------------------
+
+  /// Persists the profile (if new user) and registers the member atomically.
+  ///
+  /// [tripId] is derived from the invite document by [MemberRepository.joinTrip].
+  /// [userId] is the Firebase Auth uid of the authenticated user.
+  /// [isNewUser] controls whether [UserRepository.saveProfile] is called.
+  ///
+  /// Throws [InviteLinkInactiveException] if the invite is no longer active.
+  Future<void> submitOnboarding({
+    required String tripId,
+    required String userId,
+    required bool isNewUser,
+  }) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      final memberRepo = ref.read(memberRepositoryProvider);
+      final userRepo = ref.read(userRepositoryProvider);
+
+      // 1. Save global profile for new users (one-time-in-life).
+      if (isNewUser && _onboarding.displayName.isNotEmpty) {
+        await userRepo.saveProfile(
+          userId: userId,
+          displayName: _onboarding.displayName,
+        );
+      }
+
+      // 2. Build tags map from the onboarding state.
+      final tags = <String, dynamic>{
+        'diet': _onboarding.dietTags,
+        'pace': _onboarding.paceTags,
+        if (_onboarding.budget.isNotEmpty) 'budget': _onboarding.budget,
+      };
+
+      // 3. Atomically write memberIds arrayUnion + member doc.
+      final member = Member(
+        userId: userId,
+        alias: _onboarding.alias,
+        tags: tags,
+        joinedAt: DateTime.now(),
+      );
+
+      await memberRepo.joinTrip(
+        tripId: tripId,
+        inviteCode: arg, // arg is the inviteCode family param
+        member: member,
+      );
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+/// Family param: [inviteCode] from the deep link URL.
+///
+/// autoDispose: the notifier (and transient onboarding state) is released
+/// when the user leaves the join flow — either after success or back-press.
+final joinTripProvider = AsyncNotifierProvider.autoDispose
+    .family<JoinTripNotifier, void, String>(JoinTripNotifier.new);

--- a/app/lib/features/trips/presentation/join_alias_screen.dart
+++ b/app/lib/features/trips/presentation/join_alias_screen.dart
@@ -64,7 +64,7 @@ class _JoinAliasScreenState extends ConsumerState<JoinAliasScreen> {
 
     context.push(
       '/join/${widget.inviteCode}/tags',
-      extra: {
+      extra: <String, dynamic>{
         'tripId': widget.tripId,
         'isNewUser': widget.isNewUser,
       },

--- a/app/lib/features/trips/presentation/join_alias_screen.dart
+++ b/app/lib/features/trips/presentation/join_alias_screen.dart
@@ -1,0 +1,268 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:vamos/core/theme/vamos_colors.dart';
+import 'package:vamos/core/theme/vamos_spacing.dart';
+import 'package:vamos/core/theme/vamos_typography.dart';
+import 'package:vamos/data/models/trip.dart';
+import 'package:vamos/data/repositories/firestore_trip_repository.dart';
+import 'package:vamos/features/trips/application/join_trip_notifier.dart';
+
+/// F1.4b — Alias selection screen (shown to ALL invitees).
+///
+/// Displays a trip preview card (name, dates, facilitator alias derived from
+/// trip data) and lets the user choose their alias for this trip. The alias
+/// defaults to the current user's display name from the notifier but is
+/// editable.
+///
+/// Navigates to /join/:code/tags on "Siguiente".
+class JoinAliasScreen extends ConsumerStatefulWidget {
+  const JoinAliasScreen({
+    super.key,
+    required this.inviteCode,
+    required this.tripId,
+    required this.isNewUser,
+    required this.defaultName,
+  });
+
+  final String inviteCode;
+  final String tripId;
+
+  /// Whether the user was routed through F1.4 (profile setup). Propagated to
+  /// the tags screen so the notifier knows whether to call saveProfile.
+  final bool isNewUser;
+
+  /// Pre-filled alias — comes from Firebase Auth displayName or the name
+  /// entered in F1.4. The field is editable so the user can pick a trip alias.
+  final String defaultName;
+
+  @override
+  ConsumerState<JoinAliasScreen> createState() => _JoinAliasScreenState();
+}
+
+class _JoinAliasScreenState extends ConsumerState<JoinAliasScreen> {
+  late final TextEditingController _aliasController;
+
+  @override
+  void initState() {
+    super.initState();
+    _aliasController = TextEditingController(text: widget.defaultName);
+  }
+
+  @override
+  void dispose() {
+    _aliasController.dispose();
+    super.dispose();
+  }
+
+  void _onContinue() {
+    final alias = _aliasController.text.trim();
+    ref
+        .read(joinTripProvider(widget.inviteCode).notifier)
+        .setAlias(alias.isEmpty ? widget.defaultName : alias);
+
+    context.push(
+      '/join/${widget.inviteCode}/tags',
+      extra: {
+        'tripId': widget.tripId,
+        'isNewUser': widget.isNewUser,
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tripAsync = ref.watch(_tripWatchProvider(widget.tripId));
+
+    return Scaffold(
+      backgroundColor: VamosColors.bg,
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(VamosSpacing.lg),
+          children: [
+            const SizedBox(height: VamosSpacing.xxl),
+
+            Text(
+              'Te invitaron al viaje',
+              style: VamosTypography.displayMedium,
+            ),
+
+            const SizedBox(height: VamosSpacing.lg),
+
+            // Trip preview card
+            tripAsync.when(
+              loading: () => _TripCardSkeleton(),
+              error: (_, __) => _TripCardError(),
+              data: (trip) =>
+                  trip == null ? _TripCardError() : _TripCard(trip: trip),
+            ),
+
+            const SizedBox(height: VamosSpacing.xl),
+            const Divider(color: VamosColors.border),
+            const SizedBox(height: VamosSpacing.xl),
+
+            // Alias field
+            Text(
+              '¿Cómo te van a llamar en este viaje?',
+              style: VamosTypography.titleMedium,
+            ),
+            const SizedBox(height: VamosSpacing.md),
+            TextFormField(
+              controller: _aliasController,
+              onChanged: (_) => setState(() {}),
+              textCapitalization: TextCapitalization.words,
+              style: VamosTypography.bodyLarge,
+              decoration: InputDecoration(
+                hintText: widget.defaultName,
+                hintStyle:
+                    VamosTypography.bodyLarge.copyWith(color: VamosColors.textMuted),
+                filled: true,
+                fillColor: VamosColors.surface,
+                contentPadding: const EdgeInsets.symmetric(
+                  horizontal: VamosSpacing.md,
+                  vertical: VamosSpacing.md,
+                ),
+                border: OutlineInputBorder(
+                  borderRadius: VamosRadius.brMd,
+                  borderSide: const BorderSide(color: VamosColors.border),
+                ),
+                enabledBorder: OutlineInputBorder(
+                  borderRadius: VamosRadius.brMd,
+                  borderSide: const BorderSide(color: VamosColors.border),
+                ),
+                focusedBorder: OutlineInputBorder(
+                  borderRadius: VamosRadius.brMd,
+                  borderSide: const BorderSide(color: VamosColors.sol500, width: 2),
+                ),
+              ),
+            ),
+            const SizedBox(height: VamosSpacing.sm),
+            Text(
+              'Podés usar tu apodo, nickname o como te llame el grupo.',
+              style: VamosTypography.bodyMedium,
+            ),
+
+            const SizedBox(height: VamosSpacing.xxxl),
+
+            // CTA — always enabled (defaultName is the fallback if field is empty)
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
+                onPressed: _onContinue,
+                style: FilledButton.styleFrom(
+                  backgroundColor: VamosColors.sol500,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: VamosRadius.brFull,
+                  ),
+                  padding: const EdgeInsets.symmetric(
+                    vertical: VamosSpacing.md,
+                  ),
+                ),
+                child: Text(
+                  'Siguiente',
+                  style: VamosTypography.titleMedium.copyWith(
+                    color: VamosColors.textOnDark,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Trip preview card
+// ---------------------------------------------------------------------------
+
+class _TripCard extends StatelessWidget {
+  const _TripCard({required this.trip});
+  final Trip trip;
+
+  @override
+  Widget build(BuildContext context) {
+    final dateFormat = DateFormat('d MMM yyyy', 'es');
+    final start = dateFormat.format(trip.startDate);
+    final end = dateFormat.format(trip.endDate);
+
+    return Card(
+      elevation: 0,
+      color: VamosColors.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: VamosRadius.brLg,
+        side: const BorderSide(color: VamosColors.border),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(VamosSpacing.lg),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(trip.name, style: VamosTypography.titleMedium),
+            const SizedBox(height: VamosSpacing.xs),
+            Text(
+              '$start – $end',
+              style: VamosTypography.monoMedium.copyWith(
+                color: VamosColors.text3,
+              ),
+            ),
+            const SizedBox(height: VamosSpacing.xs),
+            Text(
+              trip.destination,
+              style: VamosTypography.bodyMedium,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TripCardSkeleton extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 0,
+      color: VamosColors.surface2,
+      shape: RoundedRectangleBorder(
+        borderRadius: VamosRadius.brLg,
+        side: const BorderSide(color: VamosColors.border),
+      ),
+      child: const SizedBox(height: 88),
+    );
+  }
+}
+
+class _TripCardError extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 0,
+      color: VamosColors.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: VamosRadius.brLg,
+        side: const BorderSide(color: VamosColors.border),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(VamosSpacing.lg),
+        child: Text(
+          'No se pudo cargar el viaje.',
+          style: VamosTypography.bodyMedium.copyWith(color: VamosColors.text3),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private provider — scoped to this file
+// ---------------------------------------------------------------------------
+
+/// Watches a single trip document. autoDispose + family so it is released
+/// when the screen leaves the tree.
+final _tripWatchProvider = StreamProvider.autoDispose
+    .family<Trip?, String>((ref, tripId) {
+  return ref.watch(tripRepositoryProvider).watchById(tripId);
+});

--- a/app/lib/features/trips/presentation/join_alias_screen.dart
+++ b/app/lib/features/trips/presentation/join_alias_screen.dart
@@ -93,7 +93,7 @@ class _JoinAliasScreenState extends ConsumerState<JoinAliasScreen> {
             // Trip preview card
             tripAsync.when(
               loading: () => _TripCardSkeleton(),
-              error: (_, __) => _TripCardError(),
+              error: (e, _) => _TripCardError(),
               data: (trip) =>
                   trip == null ? _TripCardError() : _TripCard(trip: trip),
             ),

--- a/app/lib/features/trips/presentation/join_entry_screen.dart
+++ b/app/lib/features/trips/presentation/join_entry_screen.dart
@@ -1,0 +1,174 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:vamos/core/theme/vamos_colors.dart';
+import 'package:vamos/core/theme/vamos_spacing.dart';
+import 'package:vamos/core/theme/vamos_typography.dart';
+import 'package:vamos/data/repositories/firestore_invite_repository.dart';
+import 'package:vamos/data/repositories/firestore_user_repository.dart';
+import 'package:vamos/data/repositories/invite_repository.dart';
+import 'package:vamos/data/repositories/user_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Async provider: resolves invite + user profile status in one shot
+// ---------------------------------------------------------------------------
+
+/// Holds the data resolved when entering the join flow.
+class _JoinEntryData {
+  const _JoinEntryData({
+    required this.tripId,
+    required this.isNewUser,
+    required this.displayName,
+  });
+
+  final String tripId;
+
+  /// True when `users/{uid}` does not exist yet → show F1.4 profile screen.
+  final bool isNewUser;
+
+  /// Default alias = Firebase Auth displayName or empty string.
+  final String displayName;
+}
+
+/// Resolves the invite code into a trip ID and checks whether the current
+/// user already has a Vamos profile.
+///
+/// Throws [InviteNotFoundException] if the invite document is missing or
+/// inactive.
+final _joinEntryProvider = FutureProvider.autoDispose
+    .family<_JoinEntryData, String>((ref, inviteCode) async {
+  final inviteRepo = ref.read(inviteRepositoryProvider);
+  final userRepo = ref.read(userRepositoryProvider);
+
+  // Resolve the invite doc to get tripId.
+  final tripId = await inviteRepo.getTripId(inviteCode);
+  if (tripId == null) throw const _InviteNotFoundException();
+
+  final uid = FirebaseAuth.instance.currentUser?.uid ?? '';
+  final displayName = FirebaseAuth.instance.currentUser?.displayName ?? '';
+
+  final isNewUser = uid.isEmpty ? true : !(await userRepo.profileExists(uid));
+
+  return _JoinEntryData(
+    tripId: tripId,
+    isNewUser: isNewUser,
+    displayName: displayName,
+  );
+});
+
+class _InviteNotFoundException implements Exception {
+  const _InviteNotFoundException();
+}
+
+// ---------------------------------------------------------------------------
+// Screen
+// ---------------------------------------------------------------------------
+
+/// Entry point for the join flow — `/join/:code`.
+///
+/// Resolves the invite and profile status, then automatically navigates:
+///   - New user  → /join/:code/profile (F1.4)
+///   - Returning → /join/:code/alias   (F1.4b)
+///
+/// Shows a loading state while resolving. If the invite is invalid/inactive,
+/// shows an error with a fallback to go home.
+class JoinEntryScreen extends ConsumerWidget {
+  const JoinEntryScreen({super.key, required this.inviteCode});
+
+  final String inviteCode;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final entryAsync = ref.watch(_joinEntryProvider(inviteCode));
+
+    return Scaffold(
+      backgroundColor: VamosColors.bg,
+      body: SafeArea(
+        child: entryAsync.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (err, _) => _ErrorBody(
+            message: err is _InviteNotFoundException
+                ? 'Este link ya no está activo.'
+                : 'No se pudo cargar el viaje. Intentá de nuevo.',
+            onGoHome: () => context.go('/trips'),
+          ),
+          data: (entry) {
+            // Navigate imperatively after the first data frame.
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (!context.mounted) return;
+              if (entry.isNewUser) {
+                context.pushReplacement(
+                  '/join/$inviteCode/profile',
+                  extra: <String, dynamic>{
+                    'tripId': entry.tripId,
+                    'defaultName': entry.displayName,
+                  },
+                );
+              } else {
+                context.pushReplacement(
+                  '/join/$inviteCode/alias',
+                  extra: <String, dynamic>{
+                    'tripId': entry.tripId,
+                    'isNewUser': false,
+                    'defaultName': entry.displayName,
+                  },
+                );
+              }
+            });
+            // Show loading while the navigation frame fires.
+            return const Center(child: CircularProgressIndicator());
+          },
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error body
+// ---------------------------------------------------------------------------
+
+class _ErrorBody extends StatelessWidget {
+  const _ErrorBody({required this.message, required this.onGoHome});
+
+  final String message;
+  final VoidCallback onGoHome;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(VamosSpacing.lg),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            message,
+            style: VamosTypography.bodyLarge,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: VamosSpacing.xl),
+          FilledButton(
+            onPressed: onGoHome,
+            style: FilledButton.styleFrom(
+              backgroundColor: VamosColors.sol500,
+              shape: RoundedRectangleBorder(
+                borderRadius: VamosRadius.brFull,
+              ),
+              padding: const EdgeInsets.symmetric(
+                horizontal: VamosSpacing.xl,
+                vertical: VamosSpacing.md,
+              ),
+            ),
+            child: Text(
+              'Ir al inicio',
+              style: VamosTypography.titleMedium.copyWith(
+                color: VamosColors.textOnDark,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/trips/presentation/join_entry_screen.dart
+++ b/app/lib/features/trips/presentation/join_entry_screen.dart
@@ -7,8 +7,6 @@ import 'package:vamos/core/theme/vamos_spacing.dart';
 import 'package:vamos/core/theme/vamos_typography.dart';
 import 'package:vamos/data/repositories/firestore_invite_repository.dart';
 import 'package:vamos/data/repositories/firestore_user_repository.dart';
-import 'package:vamos/data/repositories/invite_repository.dart';
-import 'package:vamos/data/repositories/user_repository.dart';
 
 // ---------------------------------------------------------------------------
 // Async provider: resolves invite + user profile status in one shot

--- a/app/lib/features/trips/presentation/join_profile_screen.dart
+++ b/app/lib/features/trips/presentation/join_profile_screen.dart
@@ -19,18 +19,28 @@ class JoinProfileScreen extends ConsumerStatefulWidget {
     super.key,
     required this.inviteCode,
     required this.tripId,
+    this.defaultName = '',
   });
 
   final String inviteCode;
   final String tripId;
+
+  /// Pre-filled display name from Firebase Auth (may be empty for brand-new accounts).
+  final String defaultName;
 
   @override
   ConsumerState<JoinProfileScreen> createState() => _JoinProfileScreenState();
 }
 
 class _JoinProfileScreenState extends ConsumerState<JoinProfileScreen> {
-  final _nameController = TextEditingController();
+  late final TextEditingController _nameController;
   final _formKey = GlobalKey<FormState>();
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.defaultName);
+  }
 
   @override
   void dispose() {
@@ -47,7 +57,11 @@ class _JoinProfileScreenState extends ConsumerState<JoinProfileScreen> {
 
     context.push(
       '/join/${widget.inviteCode}/alias',
-      extra: {'tripId': widget.tripId, 'isNewUser': true},
+      extra: <String, dynamic>{
+        'tripId': widget.tripId,
+        'isNewUser': true,
+        'defaultName': _nameController.text.trim(),
+      },
     );
   }
 

--- a/app/lib/features/trips/presentation/join_profile_screen.dart
+++ b/app/lib/features/trips/presentation/join_profile_screen.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:vamos/core/theme/vamos_colors.dart';
+import 'package:vamos/core/theme/vamos_spacing.dart';
+import 'package:vamos/core/theme/vamos_typography.dart';
+import 'package:vamos/features/trips/application/join_trip_notifier.dart';
+
+/// F1.4 — Profile setup screen (shown ONLY to new users).
+///
+/// Existing users skip this screen entirely — the router sends them directly
+/// to [JoinAliasScreen]. New users set their global display name here. Profile
+/// photo upload is deferred (Storage not in MVP); a disabled placeholder is
+/// shown instead.
+///
+/// On "Siguiente" → navigates to /join/:code/alias passing [tripId].
+class JoinProfileScreen extends ConsumerStatefulWidget {
+  const JoinProfileScreen({
+    super.key,
+    required this.inviteCode,
+    required this.tripId,
+  });
+
+  final String inviteCode;
+  final String tripId;
+
+  @override
+  ConsumerState<JoinProfileScreen> createState() => _JoinProfileScreenState();
+}
+
+class _JoinProfileScreenState extends ConsumerState<JoinProfileScreen> {
+  final _nameController = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  void _onContinue() {
+    if (_formKey.currentState?.validate() != true) return;
+
+    ref
+        .read(joinTripProvider(widget.inviteCode).notifier)
+        .setDisplayName(_nameController.text.trim());
+
+    context.push(
+      '/join/${widget.inviteCode}/alias',
+      extra: {'tripId': widget.tripId, 'isNewUser': true},
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final nameText = _nameController.text.trim();
+    final canContinue = nameText.isNotEmpty;
+
+    return Scaffold(
+      backgroundColor: VamosColors.bg,
+      body: SafeArea(
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            padding: const EdgeInsets.all(VamosSpacing.lg),
+            children: [
+              const SizedBox(height: VamosSpacing.xxl),
+
+              // Header
+              Text(
+                'Antes de sumarte al viaje...',
+                style: VamosTypography.displayMedium,
+              ),
+              const SizedBox(height: VamosSpacing.sm),
+              Text(
+                'Completá tu perfil una sola vez. Lo vas a usar en todos tus viajes.',
+                style: VamosTypography.bodyMedium,
+              ),
+
+              const SizedBox(height: VamosSpacing.xl),
+              const Divider(color: VamosColors.border),
+              const SizedBox(height: VamosSpacing.xl),
+
+              // Name field
+              Text('Tu nombre', style: VamosTypography.caption),
+              const SizedBox(height: VamosSpacing.sm),
+              TextFormField(
+                controller: _nameController,
+                onChanged: (_) => setState(() {}),
+                textCapitalization: TextCapitalization.words,
+                style: VamosTypography.bodyLarge,
+                decoration: InputDecoration(
+                  hintText: 'Andrés Gómez',
+                  hintStyle:
+                      VamosTypography.bodyLarge.copyWith(color: VamosColors.textMuted),
+                  filled: true,
+                  fillColor: VamosColors.surface,
+                  contentPadding: const EdgeInsets.symmetric(
+                    horizontal: VamosSpacing.md,
+                    vertical: VamosSpacing.md,
+                  ),
+                  border: OutlineInputBorder(
+                    borderRadius: VamosRadius.brMd,
+                    borderSide: const BorderSide(color: VamosColors.border),
+                  ),
+                  enabledBorder: OutlineInputBorder(
+                    borderRadius: VamosRadius.brMd,
+                    borderSide: const BorderSide(color: VamosColors.border),
+                  ),
+                  focusedBorder: OutlineInputBorder(
+                    borderRadius: VamosRadius.brMd,
+                    borderSide: const BorderSide(color: VamosColors.sol500, width: 2),
+                  ),
+                ),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Ingresá tu nombre para continuar';
+                  }
+                  return null;
+                },
+              ),
+
+              const SizedBox(height: VamosSpacing.xl),
+
+              // Photo placeholder (Storage deferred)
+              Text('Foto de perfil (opcional)', style: VamosTypography.caption),
+              const SizedBox(height: VamosSpacing.sm),
+              _PhotoPlaceholder(),
+
+              const SizedBox(height: VamosSpacing.sm),
+              Text(
+                'En tu perfil sos vos. Podés usar un apodo diferente en cada viaje en la pantalla siguiente.',
+                style: VamosTypography.bodyMedium,
+              ),
+
+              const SizedBox(height: VamosSpacing.xxxl),
+
+              // CTA
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  onPressed: canContinue ? _onContinue : null,
+                  style: FilledButton.styleFrom(
+                    backgroundColor: VamosColors.sol500,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: VamosRadius.brFull,
+                    ),
+                    padding: const EdgeInsets.symmetric(
+                      vertical: VamosSpacing.md,
+                    ),
+                  ),
+                  child: Text(
+                    'Siguiente',
+                    style: VamosTypography.titleMedium.copyWith(
+                      color: VamosColors.textOnDark,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Photo placeholder widget
+// ---------------------------------------------------------------------------
+
+/// Disabled photo upload placeholder. Storage upload is deferred to v1.1+.
+class _PhotoPlaceholder extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 80,
+      decoration: BoxDecoration(
+        color: VamosColors.surface2,
+        borderRadius: VamosRadius.brMd,
+        border: Border.all(color: VamosColors.border),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.add_a_photo_outlined,
+            size: VamosSpacing.lg,
+            color: VamosColors.textMuted,
+          ),
+          const SizedBox(width: VamosSpacing.sm),
+          Text(
+            'Foto · próximamente',
+            style: VamosTypography.bodyMedium.copyWith(
+              color: VamosColors.textMuted,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/trips/presentation/join_tags_screen.dart
+++ b/app/lib/features/trips/presentation/join_tags_screen.dart
@@ -1,0 +1,329 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:vamos/core/theme/vamos_colors.dart';
+import 'package:vamos/core/theme/vamos_spacing.dart';
+import 'package:vamos/core/theme/vamos_typography.dart';
+import 'package:vamos/data/repositories/member_repository.dart';
+import 'package:vamos/features/trips/application/join_trip_notifier.dart';
+
+// ---------------------------------------------------------------------------
+// Tag constants (source: docs/06-identidad-y-tono.md)
+// ---------------------------------------------------------------------------
+
+const _dietOptions = [
+  'vegetariano',
+  'vegano',
+  'celíaco',
+  'sin-lactosa',
+  'sin-mariscos',
+  'halal',
+  'kosher',
+];
+
+const _paceOptions = [
+  'camina mucho',
+  'ritmo tranquilo',
+  'nocturno',
+  'madrugador',
+];
+
+const _budgetOptions = [
+  'ajustado',
+  'medio',
+  'amplio',
+];
+
+// ---------------------------------------------------------------------------
+// Screen
+// ---------------------------------------------------------------------------
+
+/// F1.5 — Preference tags screen (shown to ALL invitees as the last step).
+///
+/// Multi-select for diet restrictions and pace tags; single-select for budget.
+/// The "Entrar al viaje" button is always enabled — tags are optional (A3 scope
+/// decision). On submit → calls [JoinTripNotifier.submitOnboarding], then
+/// navigates to `/trips/:tripId` on success.
+///
+/// Exact header microcopy from `docs/06-identidad-y-tono.md` §5.3:
+///   "Esto lo va a ver el grupo. Saltá lo que no aplique."
+class JoinTagsScreen extends ConsumerStatefulWidget {
+  const JoinTagsScreen({
+    super.key,
+    required this.inviteCode,
+    required this.tripId,
+    required this.isNewUser,
+  });
+
+  final String inviteCode;
+  final String tripId;
+  final bool isNewUser;
+
+  @override
+  ConsumerState<JoinTagsScreen> createState() => _JoinTagsScreenState();
+}
+
+class _JoinTagsScreenState extends ConsumerState<JoinTagsScreen> {
+  final Set<String> _selectedDiet = {};
+  final Set<String> _selectedPace = {};
+  String _selectedBudget = '';
+
+  void _toggleDiet(String tag) {
+    setState(() {
+      if (_selectedDiet.contains(tag)) {
+        _selectedDiet.remove(tag);
+      } else {
+        _selectedDiet.add(tag);
+      }
+    });
+  }
+
+  void _togglePace(String tag) {
+    setState(() {
+      if (_selectedPace.contains(tag)) {
+        _selectedPace.remove(tag);
+      } else {
+        _selectedPace.add(tag);
+      }
+    });
+  }
+
+  void _selectBudget(String option) {
+    setState(() {
+      _selectedBudget = _selectedBudget == option ? '' : option;
+    });
+  }
+
+  Future<void> _onSubmit() async {
+    final notifier = ref.read(joinTripProvider(widget.inviteCode).notifier);
+    notifier.setDietTags(_selectedDiet.toList());
+    notifier.setPaceTags(_selectedPace.toList());
+    notifier.setBudget(_selectedBudget);
+
+    final userId = FirebaseAuth.instance.currentUser?.uid ?? '';
+
+    await notifier.submitOnboarding(
+      tripId: widget.tripId,
+      userId: userId,
+      isNewUser: widget.isNewUser,
+    );
+
+    if (!mounted) return;
+    final joinState = ref.read(joinTripProvider(widget.inviteCode));
+    joinState.when(
+      data: (_) => context.go('/trips/${widget.tripId}'),
+      error: (err, _) => _showError(err),
+      loading: () {},
+    );
+  }
+
+  void _showError(Object err) {
+    final message = err is InviteLinkInactiveException
+        ? 'Este link ya no está activo.'
+        : 'No se pudo unir al viaje. Intentá de nuevo.';
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message, style: VamosTypography.bodyMedium),
+        backgroundColor: VamosColors.red,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final joinAsync = ref.watch(joinTripProvider(widget.inviteCode));
+    final isSubmitting = joinAsync.isLoading;
+
+    // Listen for errors after build — surfaces async errors in a snackbar.
+    ref.listen(joinTripProvider(widget.inviteCode), (_, next) {
+      if (next.hasError) _showError(next.error!);
+    });
+
+    return Scaffold(
+      backgroundColor: VamosColors.bg,
+      appBar: AppBar(
+        backgroundColor: VamosColors.bg,
+        elevation: 0,
+        title: Text(
+          'Contanos un poco',
+          style: VamosTypography.headlineMedium,
+        ),
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Expanded(
+              child: ListView(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: VamosSpacing.lg,
+                  vertical: VamosSpacing.md,
+                ),
+                children: [
+                  // Header microcopy — exact string from §5.3
+                  Text(
+                    'Esto lo va a ver el grupo. Saltá lo que no aplique.',
+                    style: VamosTypography.bodyMedium,
+                  ),
+
+                  const SizedBox(height: VamosSpacing.lg),
+                  const Divider(color: VamosColors.border),
+                  const SizedBox(height: VamosSpacing.lg),
+
+                  // Diet section
+                  _SectionHeader(label: '¿Comés de todo?'),
+                  const SizedBox(height: VamosSpacing.sm),
+                  _TagGroup(
+                    options: _dietOptions,
+                    selected: _selectedDiet,
+                    onToggle: _toggleDiet,
+                    multiSelect: true,
+                  ),
+
+                  const SizedBox(height: VamosSpacing.lg),
+                  const Divider(color: VamosColors.border),
+                  const SizedBox(height: VamosSpacing.lg),
+
+                  // Pace section
+                  _SectionHeader(label: 'Estilo de viaje'),
+                  const SizedBox(height: VamosSpacing.sm),
+                  _TagGroup(
+                    options: _paceOptions,
+                    selected: _selectedPace,
+                    onToggle: _togglePace,
+                    multiSelect: true,
+                  ),
+
+                  const SizedBox(height: VamosSpacing.lg),
+                  const Divider(color: VamosColors.border),
+                  const SizedBox(height: VamosSpacing.lg),
+
+                  // Budget section (single-select)
+                  _SectionHeader(label: 'Presupuesto cómodo'),
+                  const SizedBox(height: VamosSpacing.sm),
+                  _TagGroup(
+                    options: _budgetOptions,
+                    selected: _selectedBudget.isEmpty ? {} : {_selectedBudget},
+                    onToggle: _selectBudget,
+                    multiSelect: false,
+                  ),
+
+                  const SizedBox(height: VamosSpacing.xl),
+                ],
+              ),
+            ),
+
+            // Bottom CTA — always enabled
+            Padding(
+              padding: const EdgeInsets.fromLTRB(
+                VamosSpacing.lg,
+                VamosSpacing.sm,
+                VamosSpacing.lg,
+                VamosSpacing.lg,
+              ),
+              child: SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  onPressed: isSubmitting ? null : _onSubmit,
+                  style: FilledButton.styleFrom(
+                    backgroundColor: VamosColors.sol500,
+                    disabledBackgroundColor: VamosColors.sol500.withAlpha(120),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: VamosRadius.brFull,
+                    ),
+                    padding: const EdgeInsets.symmetric(
+                      vertical: VamosSpacing.md,
+                    ),
+                  ),
+                  child: isSubmitting
+                      ? const SizedBox(
+                          height: VamosSpacing.lg,
+                          width: VamosSpacing.lg,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            color: VamosColors.textOnDark,
+                          ),
+                        )
+                      : Text(
+                          'Entrar al viaje',
+                          style: VamosTypography.titleMedium.copyWith(
+                            color: VamosColors.textOnDark,
+                          ),
+                        ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared sub-widgets
+// ---------------------------------------------------------------------------
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.label});
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(label, style: VamosTypography.titleMedium);
+  }
+}
+
+/// Renders a wrap of selectable filter chips.
+class _TagGroup extends StatelessWidget {
+  const _TagGroup({
+    required this.options,
+    required this.selected,
+    required this.onToggle,
+    required this.multiSelect,
+  });
+
+  final List<String> options;
+  final Set<String> selected;
+  final void Function(String) onToggle;
+
+  /// When false, behaves like a single-select (radio group).
+  final bool multiSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: VamosSpacing.sm,
+      runSpacing: VamosSpacing.sm,
+      children: options.map((option) {
+        final isSelected = selected.contains(option);
+        return FilterChip(
+          label: Text(
+            option,
+            style: VamosTypography.bodyMedium.copyWith(
+              color: isSelected ? VamosColors.textOnDark : VamosColors.text2,
+              fontWeight: isSelected ? FontWeight.w600 : FontWeight.w400,
+            ),
+          ),
+          selected: isSelected,
+          onSelected: (_) => onToggle(option),
+          backgroundColor: VamosColors.surface,
+          selectedColor: VamosColors.sol500,
+          checkmarkColor: VamosColors.textOnDark,
+          side: BorderSide(
+            color: isSelected ? VamosColors.sol500 : VamosColors.border,
+          ),
+          shape: RoundedRectangleBorder(
+            borderRadius: VamosRadius.brFull,
+          ),
+          showCheckmark: false,
+          padding: const EdgeInsets.symmetric(
+            horizontal: VamosSpacing.sm,
+            vertical: VamosSpacing.xs,
+          ),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -1,11 +1,90 @@
 rules_version = '2';
 
 // Deny-all base. Per-collection rules are added as each MVP flow is implemented (X-01).
+//
+// F1-06 adds:
+//   - invites: public read (anyone with the link can resolve tripId + active status)
+//   - trips: authenticated member can update memberIds (join)
+//   - trips/{tripId}/members: authenticated user can write their own member doc
 
 service cloud.firestore {
   match /databases/{database}/documents {
+
+    // Default deny-all
     match /{document=**} {
       allow read, write: if false;
+    }
+
+    // -------------------------------------------------------------------------
+    // invites/{code}
+    //
+    // Public read by design — anyone with the link needs to resolve the tripId
+    // and check active status. Write is for authenticated users only (F1-03
+    // already covers create via InviteRepository).
+    // -------------------------------------------------------------------------
+    match /invites/{code} {
+      allow read: if true;
+      allow create: if request.auth != null;
+      allow update, delete: if false;
+    }
+
+    // -------------------------------------------------------------------------
+    // users/{userId}
+    //
+    // Users can read and write their own profile document only.
+    // -------------------------------------------------------------------------
+    match /users/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // -------------------------------------------------------------------------
+    // trips/{tripId}
+    //
+    // Read: authenticated member (uid in memberIds).
+    // Update (join): authenticated user not yet in memberIds — only the
+    //   memberIds field can be changed via arrayUnion during the join flow.
+    //   Existing members can perform general updates.
+    // Create: authenticated user (facilitator during trip creation).
+    // Delete: not allowed — only archive (status field update).
+    // -------------------------------------------------------------------------
+    match /trips/{tripId} {
+      allow read: if request.auth != null
+        && request.auth.uid in resource.data.memberIds;
+
+      allow create: if request.auth != null;
+
+      // Joining: user not yet in memberIds — may only arrayUnion their own uid.
+      // Existing member: full update access.
+      allow update: if request.auth != null && (
+        request.auth.uid in resource.data.memberIds
+        || (
+          // The only field being changed is memberIds and the new value
+          // includes the requesting user's uid.
+          request.resource.data.diff(resource.data).affectedKeys()
+              .hasOnly(['memberIds'])
+          && request.auth.uid in request.resource.data.memberIds
+        )
+      );
+
+      allow delete: if false;
+
+      // -----------------------------------------------------------------------
+      // trips/{tripId}/members/{userId}
+      //
+      // Read: any trip member.
+      // Write: the user writes only their own member document (during join).
+      //   Subsequent edits from existing members are allowed too.
+      // Delete: not allowed in MVP.
+      // -----------------------------------------------------------------------
+      match /members/{userId} {
+        allow read: if request.auth != null
+          && request.auth.uid in get(/databases/$(database)/documents/trips/$(tripId)).data.memberIds;
+
+        allow create, update: if request.auth != null
+          && request.auth.uid == userId;
+
+        allow delete: if false;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- `user_repository.dart` + `firestore_user_repository.dart` — `saveProfile` + `profileExists`
- `member_repository.dart` — `joinTrip` (atomic batch: memberIds arrayUnion + members/{uid} write) + `watchByTrip`
- `join_trip_notifier.dart` — transient state across 3 onboarding screens
- 4 join screens: `join_entry_screen` (resolves invite) → `join_profile_screen` (F1.4, new users only) → `join_alias_screen` (F1.4b) → `join_tags_screen` (F1.5)
- `firestore.rules` — invites public read, users self-write, trips join guard
- Router: `/join/:code` wired to the full flow
- Profile photo upload skipped (defer:storage) — placeholder shown

## Issue

Closes #14

## Checklist

- [x] UserRepository (saveProfile + profileExists)
- [x] MemberRepository (joinTrip atomic + watchByTrip)
- [x] JoinTripNotifier with transient state
- [x] All 4 join screens (entry, profile, alias, tags)
- [x] Firestore rules updated
- [x] Router wired
- [x] flutter analyze: zero new warnings