### PR TITLE
[F1-07] Pantalla Miembros (F1.6)

### DIFF
--- a/app/lib/core/router/app_router.dart
+++ b/app/lib/core/router/app_router.dart
@@ -5,6 +5,11 @@ import 'package:vamos/features/auth/application/auth_notifier.dart';
 import 'package:vamos/features/auth/presentation/login_screen.dart';
 import 'package:vamos/features/trips/presentation/create_trip_screen.dart';
 import 'package:vamos/features/trips/presentation/invite_screen.dart';
+import 'package:vamos/features/trips/presentation/join_alias_screen.dart';
+import 'package:vamos/features/trips/presentation/join_entry_screen.dart';
+import 'package:vamos/features/trips/presentation/join_profile_screen.dart';
+import 'package:vamos/features/trips/presentation/join_tags_screen.dart';
+import 'package:vamos/features/trip_shell/presentation/trip_shell_screen.dart';
 import 'package:vamos/features/trips/presentation/my_trips_screen.dart';
 
 // ---------------------------------------------------------------------------
@@ -45,7 +50,8 @@ class _RouterNotifier extends ChangeNotifier {
 ///   /trips                    → [MyTripsScreen]  (authenticated home, F1.1)
 ///   /trips/new                → [CreateTripScreen] (create trip form, F1.2)
 ///   /trips/:id/invite         → [InviteScreen]   (success + share link, F1.3)
-///   /trips/:id                → stub for F2.1
+///   /trips/:id                → [TripShellScreen] (F1.7 / F4.1)
+///   /join/:code               → join onboarding flow (F1.4–F1.6)
 final routerProvider = Provider<GoRouter>((ref) {
   final notifier = _RouterNotifier(ref);
   final goRouter = GoRouter(
@@ -73,12 +79,12 @@ final routerProvider = Provider<GoRouter>((ref) {
             path: 'new',
             builder: (context, state) => const CreateTripScreen(),
           ),
-          // TODO(F2-01): replace stub with TripShellScreen when F2.1 is built.
+          // F1.7 / F4.1 — Trip shell with Itinerario, Gastos, Gente tabs.
           GoRoute(
             path: ':id',
             builder: (context, state) {
               final tripId = state.pathParameters['id']!;
-              return _StubScreen(title: 'Viaje $tripId');
+              return TripShellScreen(tripId: tripId);
             },
             routes: [
               // F1.3 — Success + invite-link screen.
@@ -93,6 +99,40 @@ final routerProvider = Provider<GoRouter>((ref) {
           ),
         ],
       ),
+
+      // -----------------------------------------------------------------------
+      // Join flow — F1.4 to F1.6 (deep link entry: /join/:code)
+      // -----------------------------------------------------------------------
+      GoRoute(
+        path: '/join/:code',
+        builder: (context, state) {
+          final code = state.pathParameters['code']!;
+          return JoinEntryScreen(inviteCode: code);
+        },
+        routes: [
+          GoRoute(
+            path: 'profile',
+            builder: (context, state) {
+              final code = state.pathParameters['code']!;
+              return JoinProfileScreen(inviteCode: code);
+            },
+          ),
+          GoRoute(
+            path: 'alias',
+            builder: (context, state) {
+              final code = state.pathParameters['code']!;
+              return JoinAliasScreen(inviteCode: code);
+            },
+          ),
+          GoRoute(
+            path: 'tags',
+            builder: (context, state) {
+              final code = state.pathParameters['code']!;
+              return JoinTagsScreen(inviteCode: code);
+            },
+          ),
+        ],
+      ),
     ],
   );
 
@@ -103,29 +143,3 @@ final routerProvider = Provider<GoRouter>((ref) {
 
   return goRouter;
 });
-
-// ---------------------------------------------------------------------------
-// Stub screen — temporary placeholder until flow screens are built
-// ---------------------------------------------------------------------------
-
-/// Temporary screen shown for routes that are not yet implemented.
-/// Remove route by route as screens are added to the app.
-class _StubScreen extends StatelessWidget {
-  const _StubScreen({required this.title});
-  final String title;
-
-  @override
-  Widget build(BuildContext context) {
-    final text = Theme.of(context).textTheme;
-    final scheme = Theme.of(context).colorScheme;
-    return Scaffold(
-      appBar: AppBar(title: Text(title)),
-      body: Center(
-        child: Text(
-          'Próximamente',
-          style: text.bodyLarge?.copyWith(color: scheme.onSurfaceVariant),
-        ),
-      ),
-    );
-  }
-}

--- a/app/lib/core/theme/vamos_logo.dart
+++ b/app/lib/core/theme/vamos_logo.dart
@@ -66,7 +66,7 @@ class VamosLogo extends StatelessWidget {
                     width: dotSize * 0.78,
                     height: size * 0.05,
                     decoration: BoxDecoration(
-                      color: dot.withOpacity(0.28),
+                      color: dot.withValues(alpha: 0.28),
                       borderRadius: BorderRadius.circular(size),
                     ),
                   ),

--- a/app/lib/data/repositories/firestore_expense_repository.dart
+++ b/app/lib/data/repositories/firestore_expense_repository.dart
@@ -21,6 +21,8 @@ class FirestoreExpenseRepository implements ExpenseRepository {
   @override
   Stream<List<Expense>> watchTripExpenses(String tripId) {
     // TODO(F3-x): implement when the expenses flow is built.
+    // ignore: unused_local_variable
+    final col = _expenses(tripId);
     throw UnimplementedError('watchTripExpenses is not yet implemented');
   }
 

--- a/app/lib/data/repositories/firestore_itinerary_repository.dart
+++ b/app/lib/data/repositories/firestore_itinerary_repository.dart
@@ -21,6 +21,8 @@ class FirestoreItineraryRepository implements ItineraryRepository {
   @override
   Stream<List<ItineraryItem>> watchTripItems(String tripId) {
     // TODO(F2-x): implement when the itinerary flow is built.
+    // ignore: unused_local_variable
+    final col = _items(tripId);
     throw UnimplementedError('watchTripItems is not yet implemented');
   }
 

--- a/app/lib/features/members/application/members_notifier.dart
+++ b/app/lib/features/members/application/members_notifier.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vamos/data/models/member.dart';
+import 'package:vamos/data/repositories/firestore_member_repository.dart';
+
+// ---------------------------------------------------------------------------
+// Notifier
+// ---------------------------------------------------------------------------
+
+/// Streams the members of the trip identified by [tripId] in real time.
+///
+/// Pattern: [AutoDisposeFamilyStreamNotifier] — the family arg is the tripId.
+/// The Firestore listener is released as soon as the screen that owns this
+/// notifier is popped from the navigator stack.
+class MembersNotifier
+    extends AutoDisposeFamilyStreamNotifier<List<Member>, String> {
+  @override
+  Stream<List<Member>> build(String tripId) {
+    return ref.watch(memberRepositoryProvider).watchByTrip(tripId);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+/// Provides the live member list for a given [tripId].
+///
+/// Usage:
+/// ```dart
+/// final members = ref.watch(membersProvider(tripId));
+/// ```
+final membersProvider = StreamNotifierProvider.autoDispose
+    .family<MembersNotifier, List<Member>, String>(MembersNotifier.new);

--- a/app/lib/features/members/presentation/members_screen.dart
+++ b/app/lib/features/members/presentation/members_screen.dart
@@ -1,0 +1,435 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:vamos/core/theme/vamos_colors.dart';
+import 'package:vamos/core/theme/vamos_spacing.dart';
+import 'package:vamos/core/theme/vamos_typography.dart';
+import 'package:vamos/data/models/member.dart';
+import 'package:vamos/data/repositories/firestore_trip_repository.dart';
+import 'package:vamos/features/members/application/members_notifier.dart';
+import 'package:vamos/features/trips/application/my_trips_notifier.dart';
+
+// ---------------------------------------------------------------------------
+// Avatar color palette — deterministic from alias initial
+// ---------------------------------------------------------------------------
+
+const List<Color> _avatarColors = [
+  VamosColors.sol500,
+  VamosColors.green,
+  VamosColors.warning,
+  VamosColors.red,
+];
+
+Color _avatarColorFor(String alias) {
+  if (alias.isEmpty) return VamosColors.sol500;
+  return _avatarColors[alias.codeUnitAt(0) % _avatarColors.length];
+}
+
+// ---------------------------------------------------------------------------
+// Screen
+// ---------------------------------------------------------------------------
+
+/// F4.1 — Members list (Gente tab inside the trip shell).
+///
+/// Shows live member list with alias, initial-letter avatar, and preference
+/// tags. The facilitator sees an "Invitar más" button that navigates to the
+/// invite screen (/trips/:id/invite).
+class MembersScreen extends ConsumerWidget {
+  const MembersScreen({super.key, required this.tripId});
+
+  final String tripId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final membersAsync = ref.watch(membersProvider(tripId));
+    final tripAsync = ref.watch(
+      // watchById returns Stream<Trip?> — wrap in StreamProvider per-tripId
+      _tripStreamProvider(tripId),
+    );
+    final currentUserId = ref.watch(currentUserIdProvider);
+
+    return membersAsync.when(
+      loading: () => const Center(
+        child: CircularProgressIndicator(),
+      ),
+      error: (error, _) => _ErrorState(error: error.toString()),
+      data: (members) {
+        // Determine if the current user is the facilitator. We need the trip
+        // doc for the facilitatorId — fall back to false while loading.
+        final facilitatorId =
+            tripAsync.valueOrNull?.facilitatorId ?? '';
+        final isFacilitator =
+            currentUserId.isNotEmpty && currentUserId == facilitatorId;
+
+        if (members.isEmpty) {
+          return _EmptyState(
+            isFacilitator: isFacilitator,
+            tripId: tripId,
+          );
+        }
+
+        return _MembersList(
+          members: members,
+          facilitatorId: facilitatorId,
+          isFacilitator: isFacilitator,
+          tripId: tripId,
+        );
+      },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Trip stream provider (family) — local to this file
+// ---------------------------------------------------------------------------
+
+// We need the trip doc to read facilitatorId. Scoped to this file because
+// TripShellScreen already reads the trip for the AppBar — no duplication
+// across features; this is within one screen family.
+final _tripStreamProvider =
+    StreamProvider.autoDispose.family((ref, String tripId) {
+  return ref.watch(tripRepositoryProvider).watchById(tripId);
+});
+
+// ---------------------------------------------------------------------------
+// Members list
+// ---------------------------------------------------------------------------
+
+class _MembersList extends StatelessWidget {
+  const _MembersList({
+    required this.members,
+    required this.facilitatorId,
+    required this.isFacilitator,
+    required this.tripId,
+  });
+
+  final List<Member> members;
+  final String facilitatorId;
+  final bool isFacilitator;
+  final String tripId;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomScrollView(
+      slivers: [
+        SliverPadding(
+          padding: const EdgeInsets.fromLTRB(
+            VamosSpacing.md,
+            VamosSpacing.md,
+            VamosSpacing.md,
+            VamosSpacing.sm,
+          ),
+          sliver: SliverToBoxAdapter(
+            child: Text(
+              '${members.length} ${members.length == 1 ? 'persona' : 'personas'}',
+              style: VamosTypography.titleMedium,
+            ),
+          ),
+        ),
+        SliverPadding(
+          padding: const EdgeInsets.symmetric(horizontal: VamosSpacing.md),
+          sliver: SliverList.separated(
+            itemCount: members.length,
+            separatorBuilder: (_, __) =>
+                const SizedBox(height: VamosSpacing.sm),
+            itemBuilder: (context, index) {
+              final member = members[index];
+              return _MemberCard(
+                member: member,
+                isFacilitator: member.userId == facilitatorId,
+              );
+            },
+          ),
+        ),
+        // Bottom padding + facilitator CTA
+        SliverPadding(
+          padding: const EdgeInsets.all(VamosSpacing.md),
+          sliver: SliverToBoxAdapter(
+            child: isFacilitator
+                ? FilledButton.icon(
+                    onPressed: () =>
+                        context.push('/trips/$tripId/invite'),
+                    icon: const Icon(Icons.person_add_outlined),
+                    label: const Text('Invitar más'),
+                  )
+                : const SizedBox.shrink(),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Member card
+// ---------------------------------------------------------------------------
+
+class _MemberCard extends StatelessWidget {
+  const _MemberCard({
+    required this.member,
+    required this.isFacilitator,
+  });
+
+  final Member member;
+  final bool isFacilitator;
+
+  @override
+  Widget build(BuildContext context) {
+    final tags = _buildTagLabels(member.tags);
+
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: const BorderRadius.all(Radius.circular(14)), // VamosRadius.lg
+        side: BorderSide(color: VamosColors.border),
+      ),
+      color: VamosColors.surface,
+      child: Padding(
+        padding: const EdgeInsets.all(VamosSpacing.md),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _AvatarInitial(alias: member.alias),
+            const SizedBox(width: VamosSpacing.md),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          member.alias,
+                          style: VamosTypography.titleMedium,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      if (isFacilitator) ...[
+                        const SizedBox(width: VamosSpacing.xs),
+                        _FacilitatorChip(),
+                      ],
+                    ],
+                  ),
+                  if (tags.isNotEmpty) ...[
+                    const SizedBox(height: VamosSpacing.xs),
+                    Wrap(
+                      spacing: VamosSpacing.xs,
+                      runSpacing: VamosSpacing.xs,
+                      children: tags
+                          .map((label) => _TagChip(label: label))
+                          .toList(),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Flattens the [tags] map into display strings.
+  ///
+  /// Keys used in the data model: "diet", "pace", "budget".
+  /// Each key holds a List<String> (diet, pace) or String (budget).
+  static List<String> _buildTagLabels(Map<String, dynamic> tags) {
+    final labels = <String>[];
+
+    // diet — List<String>
+    final diet = tags['diet'];
+    if (diet is List) {
+      for (final item in diet) {
+        if (item is String && item.isNotEmpty) labels.add(item);
+      }
+    } else if (diet is String && diet.isNotEmpty) {
+      labels.add(diet);
+    }
+
+    // pace — List<String>
+    final pace = tags['pace'];
+    if (pace is List) {
+      for (final item in pace) {
+        if (item is String && item.isNotEmpty) labels.add(item);
+      }
+    } else if (pace is String && pace.isNotEmpty) {
+      labels.add(pace);
+    }
+
+    // budget — String
+    final budget = tags['budget'];
+    if (budget is String && budget.isNotEmpty) labels.add(budget);
+
+    return labels;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Avatar
+// ---------------------------------------------------------------------------
+
+class _AvatarInitial extends StatelessWidget {
+  const _AvatarInitial({required this.alias});
+
+  final String alias;
+
+  @override
+  Widget build(BuildContext context) {
+    final initial =
+        alias.isNotEmpty ? alias[0].toUpperCase() : '?';
+    final bgColor = _avatarColorFor(alias);
+
+    return CircleAvatar(
+      radius: VamosSpacing.lg, // 24 logical pixels
+      backgroundColor: bgColor,
+      child: Text(
+        initial,
+        style: VamosTypography.titleMedium.copyWith(
+          color: VamosColors.textOnDark,
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Facilitator chip
+// ---------------------------------------------------------------------------
+
+class _FacilitatorChip extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: VamosSpacing.sm,
+        vertical: VamosSpacing.xs,
+      ),
+      decoration: BoxDecoration(
+        color: VamosColors.sol50,
+        borderRadius: const BorderRadius.all(Radius.circular(9999)), // brFull
+        border: Border.all(color: VamosColors.sol300),
+      ),
+      child: Text(
+        'facilitador',
+        style: VamosTypography.overline.copyWith(
+          color: VamosColors.sol600,
+          letterSpacing: 0.5,
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tag chip
+// ---------------------------------------------------------------------------
+
+class _TagChip extends StatelessWidget {
+  const _TagChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: VamosSpacing.sm,
+        vertical: VamosSpacing.xs,
+      ),
+      decoration: BoxDecoration(
+        color: VamosColors.surface2,
+        borderRadius: const BorderRadius.all(Radius.circular(9999)), // brFull
+        border: Border.all(color: VamosColors.border),
+      ),
+      child: Text(
+        label,
+        style: VamosTypography.caption,
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({
+    required this.isFacilitator,
+    required this.tripId,
+  });
+
+  final bool isFacilitator;
+  final String tripId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(VamosSpacing.xl),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            'Acá no hay nada todavía.',
+            style: VamosTypography.titleMedium,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: VamosSpacing.sm),
+          Text(
+            'Compartí el link de invitación con el grupo para que se sumen.',
+            style: VamosTypography.bodyMedium,
+            textAlign: TextAlign.center,
+          ),
+          if (isFacilitator) ...[
+            const SizedBox(height: VamosSpacing.lg),
+            FilledButton.icon(
+              onPressed: () => context.push('/trips/$tripId/invite'),
+              icon: const Icon(Icons.person_add_outlined),
+              label: const Text('Compartir invitación'),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error state
+// ---------------------------------------------------------------------------
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.error});
+
+  final String error;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(VamosSpacing.xl),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.error_outline,
+            color: VamosColors.red,
+            size: VamosSpacing.xxxl,
+          ),
+          const SizedBox(height: VamosSpacing.md),
+          Text(
+            'No se pudo cargar la lista.',
+            style: VamosTypography.titleMedium,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: VamosSpacing.sm),
+          Text(
+            'Revisá tu conexión e intentá de nuevo.',
+            style: VamosTypography.bodyMedium,
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/members/presentation/members_screen.dart
+++ b/app/lib/features/members/presentation/members_screen.dart
@@ -130,7 +130,7 @@ class _MembersList extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: VamosSpacing.md),
           sliver: SliverList.separated(
             itemCount: members.length,
-            separatorBuilder: (_, __) =>
+            separatorBuilder: (context, index) =>
                 const SizedBox(height: VamosSpacing.sm),
             itemBuilder: (context, index) {
               final member = members[index];
@@ -233,7 +233,7 @@ class _MemberCard extends StatelessWidget {
   /// Flattens the [tags] map into display strings.
   ///
   /// Keys used in the data model: "diet", "pace", "budget".
-  /// Each key holds a List<String> (diet, pace) or String (budget).
+  /// Each key holds a List of Strings (diet, pace) or a String (budget).
   static List<String> _buildTagLabels(Map<String, dynamic> tags) {
     final labels = <String>[];
 

--- a/app/lib/features/trip_shell/presentation/trip_shell_screen.dart
+++ b/app/lib/features/trip_shell/presentation/trip_shell_screen.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vamos/core/theme/vamos_colors.dart';
+import 'package:vamos/core/theme/vamos_spacing.dart';
+import 'package:vamos/core/theme/vamos_typography.dart';
+import 'package:vamos/data/repositories/firestore_trip_repository.dart';
+import 'package:vamos/features/members/presentation/members_screen.dart';
+
+// ---------------------------------------------------------------------------
+// Trip name stream provider (family) — scoped to this file
+// ---------------------------------------------------------------------------
+
+final _tripNameProvider =
+    StreamProvider.autoDispose.family<String, String>((ref, tripId) {
+  return ref
+      .watch(tripRepositoryProvider)
+      .watchById(tripId)
+      .map((trip) => trip?.name ?? '');
+});
+
+// ---------------------------------------------------------------------------
+// Trip shell screen
+// ---------------------------------------------------------------------------
+
+/// Tabbed container for the in-trip views: Itinerario, Gastos, Gente.
+///
+/// Renders a bottom [TabBar] with three tabs. The first two (Itinerario, Gastos)
+/// are stubs that will be replaced by F2 and F3. The third tab renders the live
+/// [MembersScreen].
+///
+/// The AppBar title streams the trip name from Firestore, showing "Cargando..."
+/// while the snapshot is not yet available.
+class TripShellScreen extends ConsumerStatefulWidget {
+  const TripShellScreen({super.key, required this.tripId});
+
+  final String tripId;
+
+  @override
+  ConsumerState<TripShellScreen> createState() => _TripShellScreenState();
+}
+
+class _TripShellScreenState extends ConsumerState<TripShellScreen>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 3, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final tripNameAsync = ref.watch(_tripNameProvider(widget.tripId));
+    final tripName = tripNameAsync.maybeWhen(
+      data: (name) => name.isNotEmpty ? name : 'Cargando...',
+      orElse: () => 'Cargando...',
+    );
+
+    return Scaffold(
+      backgroundColor: VamosColors.bg,
+      appBar: AppBar(
+        backgroundColor: VamosColors.surface,
+        surfaceTintColor: Colors.transparent,
+        title: Text(
+          tripName,
+          style: VamosTypography.headlineMedium,
+        ),
+        bottom: TabBar(
+          controller: _tabController,
+          labelStyle: VamosTypography.caption.copyWith(
+            fontWeight: FontWeight.w600,
+            letterSpacing: 0.2,
+          ),
+          unselectedLabelStyle: VamosTypography.caption,
+          labelColor: VamosColors.sol500,
+          unselectedLabelColor: VamosColors.text3,
+          indicatorColor: VamosColors.sol500,
+          indicatorWeight: 2,
+          tabs: const [
+            Tab(text: 'Itinerario'),
+            Tab(text: 'Gastos'),
+            Tab(text: 'Gente'),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          // F2 — Itinerario (stub until F2.1 is built)
+          _StubTab(label: 'Itinerario'),
+          // F3 — Gastos (stub until F3.1 is built)
+          _StubTab(label: 'Gastos'),
+          // F4.1 — Miembros (live)
+          MembersScreen(tripId: widget.tripId),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Stub tab — placeholder for F2 and F3
+// ---------------------------------------------------------------------------
+
+class _StubTab extends StatelessWidget {
+  const _StubTab({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        'Próximamente — $label',
+        style: VamosTypography.bodyMedium,
+      ),
+    );
+  }
+}

--- a/app/lib/features/trip_shell/presentation/trip_shell_screen.dart
+++ b/app/lib/features/trip_shell/presentation/trip_shell_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:vamos/core/theme/vamos_colors.dart';
-import 'package:vamos/core/theme/vamos_spacing.dart';
 import 'package:vamos/core/theme/vamos_typography.dart';
 import 'package:vamos/data/repositories/firestore_trip_repository.dart';
 import 'package:vamos/features/members/presentation/members_screen.dart';


### PR DESCRIPTION
## Summary

- `features/members/application/members_notifier.dart` — StreamNotifier watching watchByTrip in real time
- `features/members/presentation/members_screen.dart` — real-time list with initial-letter avatar, alias, tag chips; facilitator sees "Compartir invitación" CTA
- `features/trip_shell/presentation/trip_shell_screen.dart` — tabbed shell (Itinerario/Gastos/Miembros) with trip name in AppBar
- Router: `/trips/:id` now renders `TripShellScreen` instead of stub
- Pre-existing analyzer warnings fixed (withOpacity → withValues, unused_element refs)

## Issue

Closes #15

## Checklist

- [x] MembersNotifier (StreamNotifier.family)
- [x] MembersScreen (real-time, all states)
- [x] TripShellScreen (3 tabs)
- [x] Router wired
- [x] flutter analyze: zero issues