### PR TITLE
[F1-08] Regenerar / revocar link de invitación

### DIFF
--- a/app/lib/data/repositories/firestore_invite_repository.dart
+++ b/app/lib/data/repositories/firestore_invite_repository.dart
@@ -65,6 +65,43 @@ class FirestoreInviteRepository implements InviteRepository {
   // ---------------------------------------------------------------------------
 
   @override
+  Future<String> revokeAndRegenerate(String tripId, String createdBy) async {
+    // Find the current active invite for this trip.
+    final activeSnap = await _invites
+        .where('tripId', isEqualTo: tripId)
+        .where('active', isEqualTo: true)
+        .limit(1)
+        .get();
+
+    if (activeSnap.docs.isEmpty) {
+      throw StateError(
+        'No se encontró un link activo para el viaje $tripId.',
+      );
+    }
+
+    final existingDoc = activeSnap.docs.first;
+    final newCode = _generateCode();
+    final newDocRef = _invites.doc(newCode);
+
+    final newInvite = Invite(
+      code: newCode,
+      tripId: tripId,
+      createdBy: createdBy,
+      createdAt: DateTime.now(),
+      active: true,
+    );
+
+    final batch = _firestore.batch();
+    // Revoke the existing invite.
+    batch.update(existingDoc.reference, {'active': false});
+    // Write the new invite.
+    batch.set(newDocRef, newInvite.toFirestore());
+
+    await batch.commit();
+    return newCode;
+  }
+
+  @override
   Future<String> create(String tripId, String createdBy) async {
     const maxRetries = 3;
 

--- a/app/lib/data/repositories/invite_repository.dart
+++ b/app/lib/data/repositories/invite_repository.dart
@@ -16,4 +16,15 @@ abstract class InviteRepository {
   /// Used by [JoinEntryScreen] to resolve the invite code from the deep link
   /// into the Firestore trip ID before starting the onboarding flow.
   Future<String?> getTripId(String code);
+
+  /// Revokes the current active invite for [tripId] and generates a new one.
+  ///
+  /// In a single [WriteBatch]:
+  ///   1. Finds the active invite document for [tripId].
+  ///   2. Sets `active: false` on that document.
+  ///   3. Writes a new invite document with a fresh 6-char code.
+  ///
+  /// Returns the newly generated invite code.
+  /// Throws [StateError] if no active invite is found for [tripId].
+  Future<String> revokeAndRegenerate(String tripId, String createdBy);
 }

--- a/app/lib/features/trips/application/generate_invite_notifier.dart
+++ b/app/lib/features/trips/application/generate_invite_notifier.dart
@@ -36,6 +36,30 @@ class GenerateInviteNotifier
     state = const AsyncLoading();
     state = await AsyncValue.guard(() => _generate(arg));
   }
+
+  /// Revokes the current active invite and generates a fresh code (F1-08).
+  ///
+  /// Sets [state] to [AsyncLoading] while the batch write is in flight, then
+  /// updates to [AsyncData] with the new code (or [AsyncError] on failure).
+  /// The UI picks up the new code automatically via the state update.
+  Future<void> regenerate() async {
+    final userId = ref.read(currentUserIdProvider);
+    if (userId.isEmpty) {
+      state = AsyncError(
+        StateError('No hay un usuario autenticado.'),
+        StackTrace.current,
+      );
+      return;
+    }
+
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      final newCode = await ref
+          .read(inviteRepositoryProvider)
+          .revokeAndRegenerate(arg, userId);
+      return newCode;
+    });
+  }
 }
 
 /// Riverpod provider for [GenerateInviteNotifier].

--- a/app/lib/features/trips/presentation/invite_screen.dart
+++ b/app/lib/features/trips/presentation/invite_screen.dart
@@ -11,6 +11,7 @@ import 'package:vamos/core/theme/vamos_typography.dart';
 import 'package:vamos/data/models/trip.dart';
 import 'package:vamos/data/repositories/firestore_trip_repository.dart';
 import 'package:vamos/features/trips/application/generate_invite_notifier.dart';
+import 'package:vamos/features/trips/application/my_trips_notifier.dart';
 
 /// F1.3 — "Tu viaje está listo" — invite-link screen.
 ///
@@ -71,7 +72,7 @@ class InviteScreen extends ConsumerWidget {
 // Main content — rendered once the trip is loaded
 // ---------------------------------------------------------------------------
 
-class _Content extends StatelessWidget {
+class _Content extends ConsumerWidget {
   const _Content({
     required this.tripId,
     required this.trip,
@@ -85,7 +86,26 @@ class _Content extends StatelessWidget {
   final VoidCallback onRetryInvite;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentUserId = ref.watch(currentUserIdProvider);
+    final isFacilitator = currentUserId == trip.createdBy;
+
+    // Listen for regenerate errors and surface them as a SnackBar.
+    ref.listen<AsyncValue<String?>>(generateInviteProvider(tripId), (_, next) {
+      next.whenOrNull(
+        error: (err, _) {
+          if (context.mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text('Error al regenerar. Intentá de nuevo.'),
+                duration: Duration(seconds: 3),
+              ),
+            );
+          }
+        },
+      );
+    });
+
     return SingleChildScrollView(
       padding: const EdgeInsets.symmetric(
         horizontal: VamosSpacing.md,
@@ -163,6 +183,16 @@ class _Content extends StatelessWidget {
           }).value ??
               const SizedBox.shrink(),
 
+          // ── Regenerate link button (facilitator only) — F1-08 ────────────
+          if (isFacilitator) ...[
+            const SizedBox(height: VamosSpacing.sm),
+            _RegenerateButton(
+              tripId: tripId,
+              isLoading: inviteAsync.isLoading,
+              onRegenerate: () => _confirmRegenerate(context, ref),
+            ),
+          ],
+
           const SizedBox(height: VamosSpacing.xxl),
 
           // ── Primary CTA ───────────────────────────────────────────────────
@@ -179,6 +209,42 @@ class _Content extends StatelessWidget {
 
   String _formatDateRange(DateTime start, DateTime end) =>
       formatDateRange(start, end);
+
+  /// Shows a confirm dialog before revoking the invite link.
+  Future<void> _confirmRegenerate(BuildContext context, WidgetRef ref) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        shape: RoundedRectangleBorder(borderRadius: VamosRadius.brDialog),
+        title: const Text('Regenerar link'),
+        content: const Text(
+          '¿Querés invalidar el link actual y crear uno nuevo?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancelar'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Sí, regenerar'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true) {
+      await ref.read(generateInviteProvider(tripId).notifier).regenerate();
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Link regenerado'),
+            duration: Duration(seconds: 2),
+          ),
+        );
+      }
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -384,6 +450,39 @@ class _NativeShareButton extends StatelessWidget {
   Future<void> _shareNative(String code) async {
     final link = 'https://vamos.app/j/$code';
     await Share.share('Sumate al viaje en Vamos: $link');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Regenerate link button — F1-08, facilitator only
+// ---------------------------------------------------------------------------
+
+/// An outlined button that lets the facilitator revoke the current invite
+/// link and generate a new one. Disabled while the notifier is loading.
+class _RegenerateButton extends StatelessWidget {
+  const _RegenerateButton({
+    required this.tripId,
+    required this.isLoading,
+    required this.onRegenerate,
+  });
+
+  final String tripId;
+  final bool isLoading;
+  final VoidCallback onRegenerate;
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlinedButton.icon(
+      onPressed: isLoading ? null : onRegenerate,
+      icon: isLoading
+          ? const SizedBox(
+              width: VamosSpacing.md,
+              height: VamosSpacing.md,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : const Icon(Icons.refresh_outlined),
+      label: const Text('Regenerar link'),
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

- `InviteRepository` gets `revokeAndRegenerate(tripId, createdBy)`: marks current active invite as `active: false` and writes a new code in a single `WriteBatch`
- `GenerateInviteNotifier` gets a `regenerate()` method; the stream auto-updates the UI with the new code
- `InviteScreen` adds a gated "Regenerar link" `OutlinedButton` (only visible to the trip creator) with a confirm `AlertDialog` before executing; errors shown via SnackBar

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)