### PR TITLE
[F2] Flujo de itinerario completo (F2-02 a F2-08)

### DIFF
--- a/app/ios/Runner/GeneratedPluginRegistrant.m
+++ b/app/ios/Runner/GeneratedPluginRegistrant.m
@@ -24,12 +24,40 @@
 @import firebase_core;
 #endif
 
+#if __has_include(<google_sign_in_ios/FLTGoogleSignInPlugin.h>)
+#import <google_sign_in_ios/FLTGoogleSignInPlugin.h>
+#else
+@import google_sign_in_ios;
+#endif
+
+#if __has_include(<share_plus/FPPSharePlusPlugin.h>)
+#import <share_plus/FPPSharePlusPlugin.h>
+#else
+@import share_plus;
+#endif
+
+#if __has_include(<sign_in_with_apple/SignInWithApplePlugin.h>)
+#import <sign_in_with_apple/SignInWithApplePlugin.h>
+#else
+@import sign_in_with_apple;
+#endif
+
+#if __has_include(<url_launcher_ios/URLLauncherPlugin.h>)
+#import <url_launcher_ios/URLLauncherPlugin.h>
+#else
+@import url_launcher_ios;
+#endif
+
 @implementation GeneratedPluginRegistrant
 
 + (void)registerWithRegistry:(NSObject<FlutterPluginRegistry>*)registry {
   [FLTFirebaseFirestorePlugin registerWithRegistrar:[registry registrarForPlugin:@"FLTFirebaseFirestorePlugin"]];
   [FLTFirebaseAuthPlugin registerWithRegistrar:[registry registrarForPlugin:@"FLTFirebaseAuthPlugin"]];
   [FLTFirebaseCorePlugin registerWithRegistrar:[registry registrarForPlugin:@"FLTFirebaseCorePlugin"]];
+  [FLTGoogleSignInPlugin registerWithRegistrar:[registry registrarForPlugin:@"FLTGoogleSignInPlugin"]];
+  [FPPSharePlusPlugin registerWithRegistrar:[registry registrarForPlugin:@"FPPSharePlusPlugin"]];
+  [SignInWithApplePlugin registerWithRegistrar:[registry registrarForPlugin:@"SignInWithApplePlugin"]];
+  [URLLauncherPlugin registerWithRegistrar:[registry registrarForPlugin:@"URLLauncherPlugin"]];
 }
 
 @end

--- a/app/lib/core/router/app_router.dart
+++ b/app/lib/core/router/app_router.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:vamos/data/models/itinerary_item.dart';
+import 'package:vamos/data/models/trip.dart';
 import 'package:vamos/features/auth/application/auth_notifier.dart';
 import 'package:vamos/features/auth/presentation/login_screen.dart';
+import 'package:vamos/features/itinerary/presentation/create_item_screen.dart';
+import 'package:vamos/features/itinerary/presentation/edit_item_screen.dart';
+import 'package:vamos/features/itinerary/presentation/item_detail_screen.dart';
 import 'package:vamos/features/trips/presentation/create_trip_screen.dart';
 import 'package:vamos/features/trips/presentation/invite_screen.dart';
 import 'package:vamos/features/trips/presentation/join_alias_screen.dart';
@@ -94,6 +99,43 @@ final routerProvider = Provider<GoRouter>((ref) {
                   final tripId = state.pathParameters['id']!;
                   return InviteScreen(tripId: tripId);
                 },
+              ),
+              // F2 — Itinerary: create item
+              GoRoute(
+                path: 'items/new',
+                builder: (context, state) {
+                  final tripId = state.pathParameters['id']!;
+                  final trip = state.extra as Trip;
+                  return CreateItemScreen(tripId: tripId, trip: trip);
+                },
+              ),
+              // F2 — Itinerary: item detail (with voting, confirm, delete, move)
+              GoRoute(
+                path: 'items/:itemId',
+                builder: (context, state) {
+                  final tripId = state.pathParameters['id']!;
+                  final extra = state.extra as Map<String, dynamic>;
+                  return ItemDetailScreen(
+                    tripId: tripId,
+                    item: extra['item'] as ItineraryItem,
+                    trip: extra['trip'] as Trip,
+                  );
+                },
+                routes: [
+                  // F2 — Itinerary: edit item
+                  GoRoute(
+                    path: 'edit',
+                    builder: (context, state) {
+                      final tripId = state.pathParameters['id']!;
+                      final extra = state.extra as Map<String, dynamic>;
+                      return EditItemScreen(
+                        tripId: tripId,
+                        item: extra['item'] as ItineraryItem,
+                        trip: extra['trip'] as Trip,
+                      );
+                    },
+                  ),
+                ],
               ),
             ],
           ),

--- a/app/lib/data/models/itinerary_item.dart
+++ b/app/lib/data/models/itinerary_item.dart
@@ -1,3 +1,5 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
 /// Mirrors the `trips/{tripId}/items/{itemId}` Firestore document.
 ///
 /// See `docs/05-modelo-datos-2.md` §2.2 for the canonical schema.
@@ -53,6 +55,56 @@ class ItineraryItem {
 
   final DateTime createdAt;
   final DateTime updatedAt;
+
+  // ---------------------------------------------------------------------------
+  // Serialization
+  // ---------------------------------------------------------------------------
+
+  /// Creates an [ItineraryItem] from a Firestore [DocumentSnapshot].
+  factory ItineraryItem.fromFirestore(
+      DocumentSnapshot<Map<String, dynamic>> doc) {
+    final d = doc.data()!;
+    return ItineraryItem(
+      id: doc.id,
+      title: d['title'] as String,
+      day: (d['day'] as Timestamp).toDate(),
+      time: d['time'] as String?,
+      location: d['location'] as String?,
+      notes: d['notes'] as String?,
+      authorId: d['authorId'] as String,
+      status: d['status'] as String,
+      votes: Map<String, String>.from(
+          (d['votes'] as Map<String, dynamic>?) ?? {}),
+      estimatedCostPerPerson:
+          (d['estimatedCostPerPerson'] as num?)?.toDouble(),
+      estimatedCostCurrency: d['estimatedCostCurrency'] as String?,
+      estimatedCostExchangeRate:
+          (d['estimatedCostExchangeRate'] as num?)?.toDouble(),
+      createdAt: (d['createdAt'] as Timestamp).toDate(),
+      updatedAt: (d['updatedAt'] as Timestamp).toDate(),
+    );
+  }
+
+  /// Serializes to a Firestore-compatible map.
+  /// The document [id] is NOT included — it lives as the document key.
+  Map<String, dynamic> toMap() => {
+        'title': title,
+        'day': Timestamp.fromDate(day),
+        if (time != null) 'time': time,
+        if (location != null) 'location': location,
+        if (notes != null) 'notes': notes,
+        'authorId': authorId,
+        'status': status,
+        'votes': votes,
+        if (estimatedCostPerPerson != null)
+          'estimatedCostPerPerson': estimatedCostPerPerson,
+        if (estimatedCostCurrency != null)
+          'estimatedCostCurrency': estimatedCostCurrency,
+        if (estimatedCostExchangeRate != null)
+          'estimatedCostExchangeRate': estimatedCostExchangeRate,
+        'createdAt': Timestamp.fromDate(createdAt),
+        'updatedAt': Timestamp.fromDate(updatedAt),
+      };
 
   ItineraryItem copyWith({
     String? id,

--- a/app/lib/data/repositories/firestore_itinerary_repository.dart
+++ b/app/lib/data/repositories/firestore_itinerary_repository.dart
@@ -7,9 +7,6 @@ import 'package:vamos/data/repositories/itinerary_repository.dart';
 /// Firestore implementation of [ItineraryRepository].
 ///
 /// This is the ONLY file in the app that imports `cloud_firestore` for items.
-/// Skeleton: methods throw [UnimplementedError] until F2.x implements the
-/// itinerary flow. The interface is in place so that notifiers can depend on
-/// [ItineraryRepository] without coupling to Firebase.
 class FirestoreItineraryRepository implements ItineraryRepository {
   const FirestoreItineraryRepository(this._firestore);
 
@@ -20,10 +17,15 @@ class FirestoreItineraryRepository implements ItineraryRepository {
 
   @override
   Stream<List<ItineraryItem>> watchTripItems(String tripId) {
-    // TODO(F2-x): implement when the itinerary flow is built.
-    // ignore: unused_local_variable
-    final col = _items(tripId);
-    throw UnimplementedError('watchTripItems is not yet implemented');
+    return _items(tripId)
+        .orderBy('day')
+        .orderBy('createdAt')
+        .snapshots()
+        .map((snapshot) => snapshot.docs
+            .map((doc) => ItineraryItem.fromFirestore(
+                  doc as DocumentSnapshot<Map<String, dynamic>>,
+                ))
+            .toList());
   }
 
   @override
@@ -31,8 +33,8 @@ class FirestoreItineraryRepository implements ItineraryRepository {
     required String tripId,
     required ItineraryItem item,
   }) async {
-    // TODO(F2-x): implement when the itinerary flow is built.
-    throw UnimplementedError('createItem is not yet implemented');
+    final docRef = _items(tripId).doc(); // auto-generated ID
+    await docRef.set(item.toMap());
   }
 
   @override
@@ -40,8 +42,9 @@ class FirestoreItineraryRepository implements ItineraryRepository {
     required String tripId,
     required ItineraryItem item,
   }) async {
-    // TODO(F2-x): implement when the itinerary flow is built.
-    throw UnimplementedError('updateItem is not yet implemented');
+    await _items(tripId)
+        .doc(item.id)
+        .update(item.toMap()..['updatedAt'] = Timestamp.now());
   }
 
   @override
@@ -49,8 +52,20 @@ class FirestoreItineraryRepository implements ItineraryRepository {
     required String tripId,
     required String itemId,
   }) async {
-    // TODO(F2-x): implement when the itinerary flow is built.
-    throw UnimplementedError('deleteItem is not yet implemented');
+    await _items(tripId).doc(itemId).delete();
+  }
+
+  @override
+  Future<void> castVote({
+    required String tripId,
+    required String itemId,
+    required String userId,
+    required String vote,
+  }) async {
+    await _items(tripId).doc(itemId).update({
+      'votes.$userId': vote,
+      'updatedAt': Timestamp.now(),
+    });
   }
 }
 

--- a/app/lib/data/repositories/itinerary_repository.dart
+++ b/app/lib/data/repositories/itinerary_repository.dart
@@ -29,4 +29,15 @@ abstract class ItineraryRepository {
   /// Deletes an item. Only the author or the trip facilitator may call this.
   /// Enforcement happens in Firestore rules.
   Future<void> deleteItem({required String tripId, required String itemId});
+
+  /// Records or updates the [userId]'s vote on [itemId].
+  ///
+  /// [vote] must be "yes" or "no". The operation is idempotent: calling it
+  /// again with the same value overwrites the previous vote.
+  Future<void> castVote({
+    required String tripId,
+    required String itemId,
+    required String userId,
+    required String vote,
+  });
 }

--- a/app/lib/features/itinerary/application/item_actions_notifier.dart
+++ b/app/lib/features/itinerary/application/item_actions_notifier.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vamos/data/models/itinerary_item.dart';
+import 'package:vamos/data/repositories/firestore_itinerary_repository.dart';
+
+/// Handles one-off mutations on itinerary items: create, update, delete, vote.
+///
+/// Each method sets state to [AsyncLoading] while the operation is in flight,
+/// then to [AsyncData] or [AsyncError] on completion.
+class ItemActionsNotifier extends AutoDisposeAsyncNotifier<void> {
+  @override
+  Future<void> build() async {}
+
+  Future<void> create({
+    required String tripId,
+    required ItineraryItem item,
+  }) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      await ref.read(itineraryRepositoryProvider).createItem(
+            tripId: tripId,
+            item: item,
+          );
+    });
+  }
+
+  Future<void> updateItem({
+    required String tripId,
+    required ItineraryItem item,
+  }) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      await ref.read(itineraryRepositoryProvider).updateItem(
+            tripId: tripId,
+            item: item,
+          );
+    });
+  }
+
+  Future<void> delete({
+    required String tripId,
+    required String itemId,
+  }) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      await ref.read(itineraryRepositoryProvider).deleteItem(
+            tripId: tripId,
+            itemId: itemId,
+          );
+    });
+  }
+
+  Future<void> castVote({
+    required String tripId,
+    required String itemId,
+    required String userId,
+    required String vote,
+  }) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      await ref.read(itineraryRepositoryProvider).castVote(
+            tripId: tripId,
+            itemId: itemId,
+            userId: userId,
+            vote: vote,
+          );
+    });
+  }
+}
+
+final itemActionsProvider =
+    AsyncNotifierProvider.autoDispose<ItemActionsNotifier, void>(
+  ItemActionsNotifier.new,
+);

--- a/app/lib/features/itinerary/application/itinerary_notifier.dart
+++ b/app/lib/features/itinerary/application/itinerary_notifier.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vamos/data/models/itinerary_item.dart';
+import 'package:vamos/data/repositories/firestore_itinerary_repository.dart';
+
+/// Streams all itinerary items for a given trip, ordered by day then createdAt.
+///
+/// Uses [AutoDisposeFamilyStreamNotifier] so the listener is released when the
+/// screen that owns this provider is disposed.
+class ItineraryNotifier
+    extends AutoDisposeFamilyStreamNotifier<List<ItineraryItem>, String> {
+  @override
+  Stream<List<ItineraryItem>> build(String tripId) {
+    return ref.watch(itineraryRepositoryProvider).watchTripItems(tripId);
+  }
+}
+
+final itineraryProvider = StreamNotifierProvider.autoDispose
+    .family<ItineraryNotifier, List<ItineraryItem>, String>(
+  ItineraryNotifier.new,
+);

--- a/app/lib/features/itinerary/presentation/create_item_screen.dart
+++ b/app/lib/features/itinerary/presentation/create_item_screen.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vamos/core/theme/vamos_colors.dart';
+import 'package:vamos/core/theme/vamos_typography.dart';
+import 'package:vamos/data/models/itinerary_item.dart';
+import 'package:vamos/data/models/trip.dart';
+import 'package:vamos/features/itinerary/application/item_actions_notifier.dart';
+import 'package:vamos/features/itinerary/presentation/widgets/item_form.dart';
+import 'package:vamos/features/trips/application/my_trips_notifier.dart';
+
+/// F2.2 — Create item form.
+///
+/// Builds an [ItineraryItem] and sends it to [ItemActionsNotifier.create].
+class CreateItemScreen extends ConsumerWidget {
+  const CreateItemScreen({
+    super.key,
+    required this.tripId,
+    required this.trip,
+  });
+
+  final String tripId;
+  final Trip trip;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final actionsState = ref.watch(itemActionsProvider);
+    final isLoading = actionsState.isLoading;
+
+    // Listen for success or error
+    ref.listen<AsyncValue<void>>(itemActionsProvider, (prev, next) {
+      if (next.hasError) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Error al guardar. Intentá de nuevo.'),
+          ),
+        );
+      } else if (next.hasValue && prev?.isLoading == true) {
+        // Successfully created — pop back
+        if (context.mounted) Navigator.of(context).pop();
+      }
+    });
+
+    return Scaffold(
+      backgroundColor: VamosColors.bg,
+      appBar: AppBar(
+        backgroundColor: VamosColors.surface,
+        surfaceTintColor: Colors.transparent,
+        title: Text('Nuevo item', style: VamosTypography.headlineMedium),
+      ),
+      body: ItemForm(
+        trip: trip,
+        isLoading: isLoading,
+        onSubmit: (formData) async {
+          final userId = ref.read(currentUserIdProvider);
+          final now = DateTime.now();
+          final item = ItineraryItem(
+            id: '',
+            title: formData.title,
+            day: formData.day,
+            time: formData.time,
+            location: formData.location,
+            notes: formData.notes,
+            authorId: userId,
+            status: 'proposed',
+            votes: const {},
+            createdAt: now,
+            updatedAt: now,
+          );
+          await ref.read(itemActionsProvider.notifier).create(
+                tripId: tripId,
+                item: item,
+              );
+        },
+      ),
+    );
+  }
+}

--- a/app/lib/features/itinerary/presentation/edit_item_screen.dart
+++ b/app/lib/features/itinerary/presentation/edit_item_screen.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vamos/core/theme/vamos_colors.dart';
+import 'package:vamos/core/theme/vamos_typography.dart';
+import 'package:vamos/data/models/itinerary_item.dart';
+import 'package:vamos/data/models/trip.dart';
+import 'package:vamos/features/itinerary/application/item_actions_notifier.dart';
+import 'package:vamos/features/itinerary/presentation/widgets/item_form.dart';
+
+/// F2.7 — Edit item form.
+///
+/// Pre-fills [ItemForm] with the existing [item] values. On submit, calls
+/// [ItemActionsNotifier.update] and pops on success.
+class EditItemScreen extends ConsumerWidget {
+  const EditItemScreen({
+    super.key,
+    required this.tripId,
+    required this.item,
+    required this.trip,
+  });
+
+  final String tripId;
+  final ItineraryItem item;
+  final Trip trip;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final actionsState = ref.watch(itemActionsProvider);
+    final isLoading = actionsState.isLoading;
+
+    ref.listen<AsyncValue<void>>(itemActionsProvider, (prev, next) {
+      if (next.hasError) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Error al guardar. Intentá de nuevo.'),
+          ),
+        );
+      } else if (next.hasValue && prev?.isLoading == true) {
+        if (context.mounted) Navigator.of(context).pop();
+      }
+    });
+
+    return Scaffold(
+      backgroundColor: VamosColors.bg,
+      appBar: AppBar(
+        backgroundColor: VamosColors.surface,
+        surfaceTintColor: Colors.transparent,
+        title: Text('Editar item', style: VamosTypography.headlineMedium),
+      ),
+      body: ItemForm(
+        trip: trip,
+        isLoading: isLoading,
+        initialTitle: item.title,
+        initialDay: item.day,
+        initialTime: item.time,
+        initialLocation: item.location,
+        initialNotes: item.notes,
+        onSubmit: (formData) async {
+          final updated = item.copyWith(
+            title: formData.title,
+            day: formData.day,
+            time: formData.time,
+            location: formData.location,
+            notes: formData.notes,
+            updatedAt: DateTime.now(),
+          );
+          await ref.read(itemActionsProvider.notifier).updateItem(
+                tripId: tripId,
+                item: updated,
+              );
+        },
+      ),
+    );
+  }
+}

--- a/app/lib/features/itinerary/presentation/item_detail_screen.dart
+++ b/app/lib/features/itinerary/presentation/item_detail_screen.dart
@@ -1,0 +1,586 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:vamos/core/theme/vamos_colors.dart';
+import 'package:vamos/core/theme/vamos_spacing.dart';
+import 'package:vamos/core/theme/vamos_typography.dart';
+import 'package:vamos/data/models/itinerary_item.dart';
+import 'package:vamos/data/models/trip.dart';
+import 'package:vamos/features/itinerary/application/item_actions_notifier.dart';
+import 'package:vamos/features/trips/application/my_trips_notifier.dart';
+
+/// F2.3 — Item detail with voting (F2-04/F2-05), confirm (F2-06),
+/// edit/delete (F2-07), and move-day (F2-08).
+class ItemDetailScreen extends ConsumerWidget {
+  const ItemDetailScreen({
+    super.key,
+    required this.tripId,
+    required this.item,
+    required this.trip,
+  });
+
+  final String tripId;
+  final ItineraryItem item;
+  final Trip trip;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentUserId = ref.watch(currentUserIdProvider);
+    final isFacilitator = currentUserId == trip.facilitatorId;
+    final isAuthor = currentUserId == item.authorId;
+    final canEdit = isAuthor || isFacilitator;
+
+    // Listen for errors on actions
+    ref.listen<AsyncValue<void>>(itemActionsProvider, (prev, next) {
+      if (next.hasError) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Error al guardar. Intentá de nuevo.'),
+          ),
+        );
+      }
+    });
+
+    return Scaffold(
+      backgroundColor: VamosColors.bg,
+      appBar: AppBar(
+        backgroundColor: VamosColors.surface,
+        surfaceTintColor: Colors.transparent,
+        title: Text(
+          item.title,
+          style: VamosTypography.headlineMedium,
+        ),
+        actions: [
+          if (canEdit)
+            PopupMenuButton<_ItemAction>(
+              icon: const Icon(Icons.more_horiz),
+              onSelected: (action) =>
+                  _handleMenuAction(context, ref, action, currentUserId),
+              itemBuilder: (_) => [
+                const PopupMenuItem(
+                  value: _ItemAction.edit,
+                  child: Text('Editar'),
+                ),
+                const PopupMenuItem(
+                  value: _ItemAction.delete,
+                  child: Text(
+                    'Eliminar',
+                    style: TextStyle(color: VamosColors.red),
+                  ),
+                ),
+                const PopupMenuItem(
+                  value: _ItemAction.moveDay,
+                  child: Text('Mover de día'),
+                ),
+              ],
+            ),
+        ],
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(VamosSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // ----------------------------------------------------------------
+            // Header section
+            // ----------------------------------------------------------------
+            _ItemHeader(item: item),
+            const SizedBox(height: VamosSpacing.lg),
+            const Divider(color: VamosColors.border),
+
+            // ----------------------------------------------------------------
+            // Voting section (F2-05)
+            // ----------------------------------------------------------------
+            const SizedBox(height: VamosSpacing.md),
+            Text('Tu voto', style: VamosTypography.titleMedium),
+            const SizedBox(height: VamosSpacing.md),
+            _VoteButtons(
+              tripId: tripId,
+              item: item,
+              currentUserId: currentUserId,
+            ),
+            const SizedBox(height: VamosSpacing.lg),
+            const Divider(color: VamosColors.border),
+
+            // ----------------------------------------------------------------
+            // Voters section (F2-04)
+            // ----------------------------------------------------------------
+            const SizedBox(height: VamosSpacing.md),
+            Text('Votos del grupo', style: VamosTypography.titleMedium),
+            const SizedBox(height: VamosSpacing.sm),
+            _VotersList(item: item, currentUserId: currentUserId),
+            const SizedBox(height: VamosSpacing.lg),
+            const Divider(color: VamosColors.border),
+
+            // ----------------------------------------------------------------
+            // Actions section (F2-06)
+            // ----------------------------------------------------------------
+            const SizedBox(height: VamosSpacing.md),
+            _ActionButtons(
+              tripId: tripId,
+              item: item,
+              trip: trip,
+              isFacilitator: isFacilitator,
+              canEdit: canEdit,
+              currentUserId: currentUserId,
+            ),
+            const SizedBox(height: VamosSpacing.xl),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _handleMenuAction(
+    BuildContext context,
+    WidgetRef ref,
+    _ItemAction action,
+    String currentUserId,
+  ) {
+    switch (action) {
+      case _ItemAction.edit:
+        context.push(
+          '/trips/$tripId/items/${item.id}/edit',
+          extra: {'item': item, 'trip': trip},
+        );
+      case _ItemAction.delete:
+        _showDeleteDialog(context, ref);
+      case _ItemAction.moveDay:
+        _showMoveDayDialog(context, ref);
+    }
+  }
+
+  void _showDeleteDialog(BuildContext context, WidgetRef ref) {
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        shape: const RoundedRectangleBorder(borderRadius: VamosRadius.brDialog),
+        title: const Text('Eliminar item'),
+        content: const Text(
+          '¿Querés eliminar este item? Esta acción no se puede deshacer.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Cancelar'),
+          ),
+          TextButton(
+            style: TextButton.styleFrom(foregroundColor: VamosColors.red),
+            onPressed: () async {
+              Navigator.of(dialogContext).pop();
+              await ref.read(itemActionsProvider.notifier).delete(
+                    tripId: tripId,
+                    itemId: item.id,
+                  );
+              if (context.mounted) Navigator.of(context).pop();
+            },
+            child: const Text('Sí, eliminar'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showMoveDayDialog(BuildContext context, WidgetRef ref) {
+    // Build trip days list
+    final days = <DateTime>[];
+    var current = DateTime(
+      trip.startDate.year,
+      trip.startDate.month,
+      trip.startDate.day,
+    );
+    final end = DateTime(
+      trip.endDate.year,
+      trip.endDate.month,
+      trip.endDate.day,
+    );
+    while (!current.isAfter(end)) {
+      days.add(current);
+      current = current.add(const Duration(days: 1));
+    }
+
+    final dayFormat = DateFormat('EEE d MMM', 'es');
+    final startDay = DateTime(
+        trip.startDate.year, trip.startDate.month, trip.startDate.day);
+
+    showDialog<void>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        shape: const RoundedRectangleBorder(borderRadius: VamosRadius.brDialog),
+        title: const Text('Mover de día'),
+        content: SizedBox(
+          width: double.maxFinite,
+          child: ListView.builder(
+            shrinkWrap: true,
+            itemCount: days.length,
+            itemBuilder: (_, index) {
+              final day = days[index];
+              final dayNumber = day.difference(startDay).inDays + 1;
+              final isCurrentDay = day.year == item.day.year &&
+                  day.month == item.day.month &&
+                  day.day == item.day.day;
+              return ListTile(
+                title: Text(
+                  'Día $dayNumber — ${dayFormat.format(day)}',
+                  style: VamosTypography.bodyMedium.copyWith(
+                    color: isCurrentDay
+                        ? VamosColors.sol500
+                        : VamosColors.text,
+                  ),
+                ),
+                trailing: isCurrentDay
+                    ? const Icon(Icons.check, color: VamosColors.sol500)
+                    : null,
+                onTap: () async {
+                  Navigator.of(dialogContext).pop();
+                  final updatedItem = item.copyWith(
+                    day: day,
+                    updatedAt: DateTime.now(),
+                  );
+                  await ref.read(itemActionsProvider.notifier).updateItem(
+                        tripId: tripId,
+                        item: updatedItem,
+                      );
+                },
+              );
+            },
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Cancelar'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Menu actions enum
+// ---------------------------------------------------------------------------
+
+enum _ItemAction { edit, delete, moveDay }
+
+// ---------------------------------------------------------------------------
+// Header section
+// ---------------------------------------------------------------------------
+
+class _ItemHeader extends StatelessWidget {
+  const _ItemHeader({required this.item});
+
+  final ItineraryItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final dateFormat = DateFormat('EEE d MMM', 'es');
+    final isConfirmed = item.status == 'confirmed';
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Status
+        Row(
+          children: [
+            Text(
+              isConfirmed ? '✓ Confirmado' : '💭 Propuesto',
+              style: VamosTypography.overline.copyWith(
+                color: isConfirmed ? VamosColors.green : VamosColors.warning,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: VamosSpacing.sm),
+
+        // Title
+        Text(item.title, style: VamosTypography.displayMedium),
+        const SizedBox(height: VamosSpacing.sm),
+
+        // Date + time
+        Text(
+          [
+            dateFormat.format(item.day),
+            if (item.time != null) item.time!,
+          ].join(' · '),
+          style: VamosTypography.monoMedium.copyWith(
+            color: VamosColors.text2,
+          ),
+        ),
+
+        // Location
+        if (item.location != null) ...[
+          const SizedBox(height: VamosSpacing.xs),
+          Text(
+            item.location!,
+            style: VamosTypography.bodyMedium,
+          ),
+        ],
+
+        // Notes
+        if (item.notes != null) ...[
+          const SizedBox(height: VamosSpacing.sm),
+          Text('Notas:', style: VamosTypography.caption),
+          const SizedBox(height: VamosSpacing.xs),
+          Text(item.notes!, style: VamosTypography.bodyMedium),
+        ],
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Vote buttons (F2-05)
+// ---------------------------------------------------------------------------
+
+class _VoteButtons extends ConsumerWidget {
+  const _VoteButtons({
+    required this.tripId,
+    required this.item,
+    required this.currentUserId,
+  });
+
+  final String tripId;
+  final ItineraryItem item;
+  final String currentUserId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final myVote = item.votes[currentUserId];
+    final actionsState = ref.watch(itemActionsProvider);
+    final isLoading = actionsState.isLoading;
+
+    Future<void> castVote(String vote) async {
+      await ref.read(itemActionsProvider.notifier).castVote(
+            tripId: tripId,
+            itemId: item.id,
+            userId: currentUserId,
+            vote: vote,
+          );
+    }
+
+    return Row(
+      children: [
+        Expanded(
+          child: OutlinedButton.icon(
+            onPressed: isLoading ? null : () => castVote('yes'),
+            icon: Icon(
+              Icons.thumb_up_outlined,
+              color: myVote == 'yes' ? VamosColors.green : VamosColors.text3,
+            ),
+            label: Text(
+              'Sí',
+              style: VamosTypography.bodyMedium.copyWith(
+                color: myVote == 'yes' ? VamosColors.green : VamosColors.text3,
+                fontWeight:
+                    myVote == 'yes' ? FontWeight.w600 : FontWeight.w400,
+              ),
+            ),
+            style: OutlinedButton.styleFrom(
+              side: BorderSide(
+                color: myVote == 'yes'
+                    ? VamosColors.green
+                    : VamosColors.border,
+              ),
+              padding: const EdgeInsets.symmetric(vertical: VamosSpacing.sm),
+              shape: const RoundedRectangleBorder(
+                borderRadius: VamosRadius.brFull,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: VamosSpacing.md),
+        Expanded(
+          child: OutlinedButton.icon(
+            onPressed: isLoading ? null : () => castVote('no'),
+            icon: Icon(
+              Icons.thumb_down_outlined,
+              color: myVote == 'no' ? VamosColors.red : VamosColors.text3,
+            ),
+            label: Text(
+              'No',
+              style: VamosTypography.bodyMedium.copyWith(
+                color: myVote == 'no' ? VamosColors.red : VamosColors.text3,
+                fontWeight:
+                    myVote == 'no' ? FontWeight.w600 : FontWeight.w400,
+              ),
+            ),
+            style: OutlinedButton.styleFrom(
+              side: BorderSide(
+                color:
+                    myVote == 'no' ? VamosColors.red : VamosColors.border,
+              ),
+              padding: const EdgeInsets.symmetric(vertical: VamosSpacing.sm),
+              shape: const RoundedRectangleBorder(
+                borderRadius: VamosRadius.brFull,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Voters list (F2-04)
+// ---------------------------------------------------------------------------
+
+class _VotersList extends StatelessWidget {
+  const _VotersList({required this.item, required this.currentUserId});
+
+  final ItineraryItem item;
+  final String currentUserId;
+
+  @override
+  Widget build(BuildContext context) {
+    final yesVoters =
+        item.votes.entries.where((e) => e.value == 'yes').toList();
+    final noVoters =
+        item.votes.entries.where((e) => e.value == 'no').toList();
+
+    if (item.votes.isEmpty) {
+      return Text(
+        'Nadie votó todavía.',
+        style: VamosTypography.bodyMedium.copyWith(color: VamosColors.text3),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (yesVoters.isNotEmpty) ...[
+          Row(
+            children: [
+              const Icon(Icons.thumb_up_outlined,
+                  size: 14, color: VamosColors.green),
+              const SizedBox(width: VamosSpacing.xs),
+              Text(
+                'Sí (${yesVoters.length})',
+                style: VamosTypography.caption.copyWith(
+                  color: VamosColors.green,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: VamosSpacing.xs),
+          ...yesVoters.map(
+            (e) => Padding(
+              padding: const EdgeInsets.only(
+                left: VamosSpacing.md,
+                bottom: VamosSpacing.xs,
+              ),
+              child: Text(
+                e.key == currentUserId ? 'Vos' : _shortenUserId(e.key),
+                style: VamosTypography.bodyMedium,
+              ),
+            ),
+          ),
+          const SizedBox(height: VamosSpacing.sm),
+        ],
+        if (noVoters.isNotEmpty) ...[
+          Row(
+            children: [
+              const Icon(Icons.thumb_down_outlined,
+                  size: 14, color: VamosColors.red),
+              const SizedBox(width: VamosSpacing.xs),
+              Text(
+                'No (${noVoters.length})',
+                style: VamosTypography.caption.copyWith(
+                  color: VamosColors.red,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: VamosSpacing.xs),
+          ...noVoters.map(
+            (e) => Padding(
+              padding: const EdgeInsets.only(
+                left: VamosSpacing.md,
+                bottom: VamosSpacing.xs,
+              ),
+              child: Text(
+                e.key == currentUserId ? 'Vos' : _shortenUserId(e.key),
+                style: VamosTypography.bodyMedium,
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  /// Returns a shortened user ID for display until member aliases are available.
+  String _shortenUserId(String uid) {
+    if (uid.length <= 8) return uid;
+    return '${uid.substring(0, 4)}…${uid.substring(uid.length - 4)}';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Action buttons (F2-06 confirm, F2-07 edit/delete, F2-08 move-day)
+// ---------------------------------------------------------------------------
+
+class _ActionButtons extends ConsumerWidget {
+  const _ActionButtons({
+    required this.tripId,
+    required this.item,
+    required this.trip,
+    required this.isFacilitator,
+    required this.canEdit,
+    required this.currentUserId,
+  });
+
+  final String tripId;
+  final ItineraryItem item;
+  final Trip trip;
+  final bool isFacilitator;
+  final bool canEdit;
+  final String currentUserId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final actionsState = ref.watch(itemActionsProvider);
+    final isLoading = actionsState.isLoading;
+    final isConfirmed = item.status == 'confirmed';
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // Confirm / revert — only facilitator
+        if (isFacilitator) ...[
+          FilledButton(
+            onPressed: isLoading
+                ? null
+                : () async {
+                    final newStatus =
+                        isConfirmed ? 'proposed' : 'confirmed';
+                    final updated = item.copyWith(
+                      status: newStatus,
+                      updatedAt: DateTime.now(),
+                    );
+                    await ref.read(itemActionsProvider.notifier).updateItem(
+                          tripId: tripId,
+                          item: updated,
+                        );
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text(isConfirmed
+                              ? 'Item vuelto a propuesto.'
+                              : 'Item confirmado.'),
+                        ),
+                      );
+                    }
+                  },
+            child: Text(isConfirmed
+                ? '↩ Volver a propuesto'
+                : '✓ Confirmar item'),
+          ),
+          const SizedBox(height: VamosSpacing.sm),
+        ],
+      ],
+    );
+  }
+}

--- a/app/lib/features/itinerary/presentation/itinerary_screen.dart
+++ b/app/lib/features/itinerary/presentation/itinerary_screen.dart
@@ -1,0 +1,255 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:vamos/core/theme/vamos_colors.dart';
+import 'package:vamos/core/theme/vamos_spacing.dart';
+import 'package:vamos/core/theme/vamos_typography.dart';
+import 'package:vamos/data/models/itinerary_item.dart';
+import 'package:vamos/data/models/trip.dart';
+import 'package:vamos/features/itinerary/application/itinerary_notifier.dart';
+import 'package:vamos/features/itinerary/presentation/widgets/item_card.dart';
+
+/// F2.1 — Itinerary list grouped by day.
+///
+/// Receives [tripId] and [trip] from [TripShellScreen].
+/// Groups items by day. Days without items are not shown per wireframe spec.
+class ItineraryScreen extends ConsumerWidget {
+  const ItineraryScreen({
+    super.key,
+    required this.tripId,
+    required this.trip,
+  });
+
+  final String tripId;
+  final Trip trip;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final itemsAsync = ref.watch(itineraryProvider(tripId));
+
+    return Scaffold(
+      backgroundColor: VamosColors.bg,
+      floatingActionButton: FloatingActionButton(
+        backgroundColor: VamosColors.sol500,
+        foregroundColor: VamosColors.textOnDark,
+        onPressed: () => context.push('/trips/$tripId/items/new', extra: trip),
+        child: const Icon(Icons.add),
+      ),
+      body: itemsAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => _ErrorState(message: e.toString()),
+        data: (items) => _ItemsList(
+          tripId: tripId,
+          trip: trip,
+          items: items,
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Items grouped list
+// ---------------------------------------------------------------------------
+
+class _ItemsList extends StatelessWidget {
+  const _ItemsList({
+    required this.tripId,
+    required this.trip,
+    required this.items,
+  });
+
+  final String tripId;
+  final Trip trip;
+  final List<ItineraryItem> items;
+
+  /// Groups items by date (day only, normalized to midnight).
+  Map<DateTime, List<ItineraryItem>> _groupByDay(List<ItineraryItem> items) {
+    final map = <DateTime, List<ItineraryItem>>{};
+    for (final item in items) {
+      final key = DateTime(item.day.year, item.day.month, item.day.day);
+      (map[key] ??= []).add(item);
+    }
+    return map;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (items.isEmpty) {
+      return _EmptyState(tripId: tripId, trip: trip);
+    }
+
+    final grouped = _groupByDay(items);
+    // Sort days ascending
+    final sortedDays = grouped.keys.toList()..sort();
+
+    // Compute day number (day 1 = startDate)
+    final startDay = DateTime(
+        trip.startDate.year, trip.startDate.month, trip.startDate.day);
+
+    return ListView.builder(
+      padding: const EdgeInsets.only(
+        top: VamosSpacing.sm,
+        bottom: VamosSpacing.xxxl,
+        left: VamosSpacing.md,
+        right: VamosSpacing.md,
+      ),
+      itemCount: sortedDays.length,
+      itemBuilder: (context, index) {
+        final day = sortedDays[index];
+        final dayNumber = day.difference(startDay).inDays + 1;
+        final dayItems = grouped[day]!;
+
+        return _DaySection(
+          day: day,
+          dayNumber: dayNumber,
+          items: dayItems,
+          tripId: tripId,
+          trip: trip,
+        );
+      },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Day section
+// ---------------------------------------------------------------------------
+
+class _DaySection extends StatelessWidget {
+  const _DaySection({
+    required this.day,
+    required this.dayNumber,
+    required this.items,
+    required this.tripId,
+    required this.trip,
+  });
+
+  final DateTime day;
+  final int dayNumber;
+  final List<ItineraryItem> items;
+  final String tripId;
+  final Trip trip;
+
+  @override
+  Widget build(BuildContext context) {
+    final dateStr = DateFormat('dd/MM').format(day);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(
+            top: VamosSpacing.lg,
+            bottom: VamosSpacing.sm,
+          ),
+          child: Row(
+            children: [
+              Text(
+                'Día $dayNumber — $dateStr',
+                style: VamosTypography.overline.copyWith(
+                  color: VamosColors.text3,
+                ),
+              ),
+              const SizedBox(width: VamosSpacing.sm),
+              const Expanded(
+                child: Divider(color: VamosColors.border, thickness: 1),
+              ),
+            ],
+          ),
+        ),
+        ...items.map(
+          (item) => Padding(
+            padding: const EdgeInsets.only(bottom: VamosSpacing.sm),
+            child: ItemCard(
+              item: item,
+              onTap: () => context.push(
+                '/trips/$tripId/items/${item.id}',
+                extra: {'item': item, 'trip': trip},
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Empty state (F2.4 — validated microcopy from 06-identidad-y-tono.md §5.4)
+// ---------------------------------------------------------------------------
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.tripId, required this.trip});
+
+  final String tripId;
+  final Trip trip;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(VamosSpacing.xl),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'Acá no hay nada todavía.',
+              style: VamosTypography.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: VamosSpacing.sm),
+            Text(
+              'Cualquiera puede tirar la primera idea — un vuelo, un restaurante, lo que sea. Después se vota.',
+              style: VamosTypography.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: VamosSpacing.lg),
+            FilledButton(
+              onPressed: () =>
+                  context.push('/trips/$tripId/items/new', extra: trip),
+              child: const Text('+ Agregar primer item'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error state
+// ---------------------------------------------------------------------------
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(VamosSpacing.xl),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'Error al cargar el itinerario.',
+              style: VamosTypography.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: VamosSpacing.sm),
+            Text(
+              'Intentá de nuevo.',
+              style: VamosTypography.bodyMedium.copyWith(
+                color: VamosColors.text3,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/itinerary/presentation/widgets/item_card.dart
+++ b/app/lib/features/itinerary/presentation/widgets/item_card.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+import 'package:vamos/core/theme/vamos_colors.dart';
+import 'package:vamos/core/theme/vamos_spacing.dart';
+import 'package:vamos/core/theme/vamos_typography.dart';
+import 'package:vamos/data/models/itinerary_item.dart';
+
+/// Card for a single itinerary item in the list view (F2.1).
+///
+/// Shows: title, time (if set), location (if set), status chip, vote counts.
+class ItemCard extends StatelessWidget {
+  const ItemCard({
+    super.key,
+    required this.item,
+    required this.onTap,
+  });
+
+  final ItineraryItem item;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final yesCount =
+        item.votes.values.where((v) => v == 'yes').length;
+    final noCount =
+        item.votes.values.where((v) => v == 'no').length;
+    final isConfirmed = item.status == 'confirmed';
+
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: VamosRadius.brLg,
+        side: const BorderSide(color: VamosColors.border),
+      ),
+      color: VamosColors.surface,
+      child: InkWell(
+        borderRadius: VamosRadius.brLg,
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(VamosSpacing.md),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Status icon + title row
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    isConfirmed ? '✓' : '💭',
+                    style: VamosTypography.bodyMedium,
+                  ),
+                  const SizedBox(width: VamosSpacing.xs),
+                  Expanded(
+                    child: Text(
+                      item.title,
+                      style: VamosTypography.titleMedium,
+                    ),
+                  ),
+                  const SizedBox(width: VamosSpacing.xs),
+                  _StatusChip(confirmed: isConfirmed),
+                ],
+              ),
+
+              // Time + location
+              if (item.time != null || item.location != null) ...[
+                const SizedBox(height: VamosSpacing.xs),
+                _MetaRow(item: item),
+              ],
+
+              // Vote counts (only for proposed items)
+              if (!isConfirmed) ...[
+                const SizedBox(height: VamosSpacing.sm),
+                Row(
+                  children: [
+                    const Icon(
+                      Icons.thumb_up_outlined,
+                      size: 14,
+                      color: VamosColors.green,
+                    ),
+                    const SizedBox(width: VamosSpacing.xs),
+                    Text(
+                      '$yesCount',
+                      style: VamosTypography.monoMedium.copyWith(
+                        color: VamosColors.green,
+                        fontSize: 12,
+                      ),
+                    ),
+                    const SizedBox(width: VamosSpacing.md),
+                    const Icon(
+                      Icons.thumb_down_outlined,
+                      size: 14,
+                      color: VamosColors.red,
+                    ),
+                    const SizedBox(width: VamosSpacing.xs),
+                    Text(
+                      '$noCount',
+                      style: VamosTypography.monoMedium.copyWith(
+                        color: VamosColors.red,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Status chip
+// ---------------------------------------------------------------------------
+
+class _StatusChip extends StatelessWidget {
+  const _StatusChip({required this.confirmed});
+
+  final bool confirmed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: VamosSpacing.sm,
+        vertical: VamosSpacing.xs,
+      ),
+      decoration: BoxDecoration(
+        color: confirmed
+            ? VamosColors.green.withAlpha(26)
+            : VamosColors.warning.withAlpha(26),
+        borderRadius: VamosRadius.brFull,
+      ),
+      child: Text(
+        confirmed ? 'Confirmado' : 'Propuesto',
+        style: VamosTypography.overline.copyWith(
+          color: confirmed ? VamosColors.green : VamosColors.warning,
+          letterSpacing: 0.5,
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Meta row (time + location)
+// ---------------------------------------------------------------------------
+
+class _MetaRow extends StatelessWidget {
+  const _MetaRow({required this.item});
+
+  final ItineraryItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final parts = <String>[];
+    if (item.time != null) parts.add(item.time!);
+    if (item.location != null) parts.add(item.location!);
+
+    return Text(
+      parts.join(' · '),
+      style: VamosTypography.caption,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+    );
+  }
+}
+

--- a/app/lib/features/itinerary/presentation/widgets/item_form.dart
+++ b/app/lib/features/itinerary/presentation/widgets/item_form.dart
@@ -1,0 +1,279 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:vamos/core/theme/vamos_colors.dart';
+import 'package:vamos/core/theme/vamos_spacing.dart';
+import 'package:vamos/core/theme/vamos_typography.dart';
+import 'package:vamos/data/models/trip.dart';
+
+/// Form data produced by [ItemForm].
+class ItemFormData {
+  const ItemFormData({
+    required this.title,
+    required this.day,
+    this.time,
+    this.location,
+    this.notes,
+  });
+
+  final String title;
+  final DateTime day;
+  final String? time;
+  final String? location;
+  final String? notes;
+}
+
+/// Shared form for creating and editing itinerary items (F2.2).
+///
+/// Used by [CreateItemScreen] and [EditItemScreen]. Renders fields for title,
+/// day, time, location, and notes. Calls [onSubmit] with [ItemFormData] when
+/// the form is valid and the user presses "Guardar".
+class ItemForm extends StatefulWidget {
+  const ItemForm({
+    super.key,
+    required this.trip,
+    required this.onSubmit,
+    required this.isLoading,
+    this.initialTitle,
+    this.initialDay,
+    this.initialTime,
+    this.initialLocation,
+    this.initialNotes,
+  });
+
+  final Trip trip;
+  final Future<void> Function(ItemFormData data) onSubmit;
+  final bool isLoading;
+
+  // Pre-fill values (for editing)
+  final String? initialTitle;
+  final DateTime? initialDay;
+  final String? initialTime;
+  final String? initialLocation;
+  final String? initialNotes;
+
+  @override
+  State<ItemForm> createState() => _ItemFormState();
+}
+
+class _ItemFormState extends State<ItemForm> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _titleController;
+  late final TextEditingController _locationController;
+  late final TextEditingController _notesController;
+
+  late DateTime _selectedDay;
+  String? _selectedTime; // null = "Sin hora"
+
+  /// Generates trip days from startDate to endDate inclusive.
+  List<DateTime> get _tripDays {
+    final days = <DateTime>[];
+    var current = DateTime(
+      widget.trip.startDate.year,
+      widget.trip.startDate.month,
+      widget.trip.startDate.day,
+    );
+    final end = DateTime(
+      widget.trip.endDate.year,
+      widget.trip.endDate.month,
+      widget.trip.endDate.day,
+    );
+    while (!current.isAfter(end)) {
+      days.add(current);
+      current = current.add(const Duration(days: 1));
+    }
+    return days;
+  }
+
+  /// Generates time options at 15-minute intervals from 00:00 to 23:45.
+  List<String> get _timeOptions {
+    final options = <String>[];
+    for (var h = 0; h < 24; h++) {
+      for (var m = 0; m < 60; m += 15) {
+        final hStr = h.toString().padLeft(2, '0');
+        final mStr = m.toString().padLeft(2, '0');
+        options.add('$hStr:$mStr');
+      }
+    }
+    return options;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _titleController =
+        TextEditingController(text: widget.initialTitle ?? '');
+    _locationController =
+        TextEditingController(text: widget.initialLocation ?? '');
+    _notesController =
+        TextEditingController(text: widget.initialNotes ?? '');
+
+    // Default day: initialDay or first trip day
+    final tripDays = _tripDays;
+    if (widget.initialDay != null) {
+      final normalised = DateTime(
+        widget.initialDay!.year,
+        widget.initialDay!.month,
+        widget.initialDay!.day,
+      );
+      _selectedDay = tripDays.contains(normalised)
+          ? normalised
+          : tripDays.first;
+    } else {
+      _selectedDay = tripDays.first;
+    }
+
+    _selectedTime = widget.initialTime;
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _locationController.dispose();
+    _notesController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _handleSubmit() async {
+    if (!(_formKey.currentState?.validate() ?? false)) return;
+    final data = ItemFormData(
+      title: _titleController.text.trim(),
+      day: _selectedDay,
+      time: _selectedTime,
+      location: _locationController.text.trim().isEmpty
+          ? null
+          : _locationController.text.trim(),
+      notes: _notesController.text.trim().isEmpty
+          ? null
+          : _notesController.text.trim(),
+    );
+    await widget.onSubmit(data);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final dayFormat = DateFormat('EEE d MMM', 'es');
+    final tripDays = _tripDays;
+    final timeOptions = _timeOptions;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(VamosSpacing.md),
+      child: Form(
+        key: _formKey,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            // ---- Título ----
+            Text('Título', style: VamosTypography.caption),
+            const SizedBox(height: VamosSpacing.xs),
+            TextFormField(
+              controller: _titleController,
+              textCapitalization: TextCapitalization.sentences,
+              decoration: const InputDecoration(
+                hintText: 'Ej: Cena en Aprazível',
+              ),
+              validator: (v) =>
+                  (v == null || v.trim().isEmpty) ? 'El título es obligatorio' : null,
+            ),
+            const SizedBox(height: VamosSpacing.lg),
+
+            // ---- Día ----
+            Text('Día', style: VamosTypography.caption),
+            const SizedBox(height: VamosSpacing.xs),
+            DropdownButtonFormField<DateTime>(
+              value: _selectedDay,
+              decoration: const InputDecoration(),
+              items: tripDays.map((day) {
+                return DropdownMenuItem(
+                  value: day,
+                  child: Text(
+                    dayFormat.format(day),
+                    style: VamosTypography.bodyMedium,
+                  ),
+                );
+              }).toList(),
+              onChanged: (value) {
+                if (value != null) setState(() => _selectedDay = value);
+              },
+              validator: (_) => null,
+            ),
+            const SizedBox(height: VamosSpacing.lg),
+
+            // ---- Hora (opcional) ----
+            Text(
+              'Hora (opcional)',
+              style: VamosTypography.caption,
+            ),
+            const SizedBox(height: VamosSpacing.xs),
+            DropdownButtonFormField<String?>(
+              value: _selectedTime,
+              decoration: const InputDecoration(),
+              items: [
+                const DropdownMenuItem<String?>(
+                  value: null,
+                  child: Text('Sin hora'),
+                ),
+                ...timeOptions.map(
+                  (t) => DropdownMenuItem<String?>(
+                    value: t,
+                    child: Text(
+                      t,
+                      style: VamosTypography.monoMedium,
+                    ),
+                  ),
+                ),
+              ],
+              onChanged: (value) => setState(() => _selectedTime = value),
+            ),
+            const SizedBox(height: VamosSpacing.lg),
+
+            // ---- Ubicación (opcional) ----
+            Text(
+              'Ubicación (opcional)',
+              style: VamosTypography.caption,
+            ),
+            const SizedBox(height: VamosSpacing.xs),
+            TextFormField(
+              controller: _locationController,
+              textCapitalization: TextCapitalization.sentences,
+              decoration: const InputDecoration(
+                hintText: 'Ej: R. Aprazível 62, Santa Teresa',
+              ),
+            ),
+            const SizedBox(height: VamosSpacing.lg),
+
+            // ---- Notas (opcional) ----
+            Text(
+              'Notas (opcional)',
+              style: VamosTypography.caption,
+            ),
+            const SizedBox(height: VamosSpacing.xs),
+            TextFormField(
+              controller: _notesController,
+              maxLines: 3,
+              textCapitalization: TextCapitalization.sentences,
+              decoration: const InputDecoration(
+                hintText: 'Reservar con anticipación, etc.',
+              ),
+            ),
+            const SizedBox(height: VamosSpacing.xl),
+
+            // ---- Submit ----
+            FilledButton(
+              onPressed: widget.isLoading ? null : _handleSubmit,
+              child: widget.isLoading
+                  ? const SizedBox(
+                      height: 20,
+                      width: 20,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: VamosColors.textOnDark,
+                      ),
+                    )
+                  : const Text('Guardar'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/trip_shell/presentation/trip_shell_screen.dart
+++ b/app/lib/features/trip_shell/presentation/trip_shell_screen.dart
@@ -2,19 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:vamos/core/theme/vamos_colors.dart';
 import 'package:vamos/core/theme/vamos_typography.dart';
+import 'package:vamos/data/models/trip.dart';
 import 'package:vamos/data/repositories/firestore_trip_repository.dart';
+import 'package:vamos/features/itinerary/presentation/itinerary_screen.dart';
 import 'package:vamos/features/members/presentation/members_screen.dart';
 
 // ---------------------------------------------------------------------------
-// Trip name stream provider (family) — scoped to this file
+// Trip stream provider (family) — scoped to this file
 // ---------------------------------------------------------------------------
 
-final _tripNameProvider =
-    StreamProvider.autoDispose.family<String, String>((ref, tripId) {
-  return ref
-      .watch(tripRepositoryProvider)
-      .watchById(tripId)
-      .map((trip) => trip?.name ?? '');
+/// Streams the full [Trip] object for use in the shell and its child tabs.
+final _tripProvider =
+    StreamProvider.autoDispose.family<Trip?, String>((ref, tripId) {
+  return ref.watch(tripRepositoryProvider).watchById(tripId);
 });
 
 // ---------------------------------------------------------------------------
@@ -56,11 +56,9 @@ class _TripShellScreenState extends ConsumerState<TripShellScreen>
 
   @override
   Widget build(BuildContext context) {
-    final tripNameAsync = ref.watch(_tripNameProvider(widget.tripId));
-    final tripName = tripNameAsync.maybeWhen(
-      data: (name) => name.isNotEmpty ? name : 'Cargando...',
-      orElse: () => 'Cargando...',
-    );
+    final tripAsync = ref.watch(_tripProvider(widget.tripId));
+    final trip = tripAsync.value;
+    final tripName = trip?.name ?? 'Cargando...';
 
     return Scaffold(
       backgroundColor: VamosColors.bg,
@@ -92,8 +90,10 @@ class _TripShellScreenState extends ConsumerState<TripShellScreen>
       body: TabBarView(
         controller: _tabController,
         children: [
-          // F2 — Itinerario (stub until F2.1 is built)
-          _StubTab(label: 'Itinerario'),
+          // F2 — Itinerario (live when trip is loaded, loading spinner otherwise)
+          trip != null
+              ? ItineraryScreen(tripId: widget.tripId, trip: trip)
+              : const Center(child: CircularProgressIndicator()),
           // F3 — Gastos (stub until F3.1 is built)
           _StubTab(label: 'Gastos'),
           // F4.1 — Miembros (live)


### PR DESCRIPTION
## Summary

- **FirestoreItineraryRepository**: implemented all stubs (`watchTripItems`, `createItem`, `updateItem`, `deleteItem`) + new `castVote` using dot-notation map update
- **ItineraryItem**: added `fromFirestore` factory and `toMap()` serialization
- **ItineraryScreen** (F2-02): live list grouped by day with section headers ("Día N — dd/mm"), item cards with vote counts, FAB to create
- **CreateItemScreen** (F2-03): form with title, day, time, location, notes; status starts `proposed`
- **ItemDetailScreen** (F2-04/F2-05/F2-06/F2-07/F2-08): full detail view with voting (idempotent, per member), confirm (facilitator), edit, delete (with confirm dialog), move-to-day dialog
- **EditItemScreen** (F2-07): pre-filled form reusing shared `ItemForm` widget
- **TripShellScreen**: replaced Itinerario stub with live `ItineraryScreen`
- **Router**: added `/trips/:id/items/new`, `/trips/:id/items/:itemId`, `/trips/:id/items/:itemId/edit`

Closes #18
Closes #19
Closes #20
Closes #21
Closes #22
Closes #23
Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)