### PR TITLE
[X-08] Release build configuration (Android + iOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,31 @@ Estas reglas aplican a Cowork mientras ejecuta las tareas:
 - No agregar dependencias, archivos o carpetas que no estén en este README. Si surge una duda, alertar al usuario antes de tomar la decisión.
 - Si alguna tarea falla (ej: un archivo de los esperados no existe, un permiso falta), alertar al usuario y no continuar con las siguientes tareas.
 
+## Release builds
+
+### Android (Play Internal Testing)
+
+1. Copy `app/android/key.properties.example` to `app/android/key.properties` and fill in your keystore path and passwords. This file is gitignored and must never be committed.
+2. Run:
+   ```bash
+   cd app/android && make build-android-release
+   ```
+   The signed AAB lands at `app/build/app/outputs/bundle/release/app-release.aab`.
+3. Upload the AAB to Google Play Console → Internal Testing.
+
+### iOS (TestFlight)
+
+1. Copy `app/ios/ExportOptions.plist.example` to `app/ios/ExportOptions.plist` and fill in your `teamID`. This file is gitignored.
+2. Make sure your Apple Developer account is signed in to Xcode and the provisioning profile for `com.jabsolutions.vamos` is installed.
+3. Run:
+   ```bash
+   app/ios/release_build.sh
+   ```
+   The IPA lands at `app/build/ios-release/vamos.ipa`.
+4. Upload via Xcode Organizer or `xcrun altool`.
+
+---
+
 ## 7. Referencias
 
 - Producto: `docs/02-prd-inicial.md` (PRD), `docs/03-mvp-scope.md` (alcance del MVP)

--- a/app/android/Makefile
+++ b/app/android/Makefile
@@ -1,0 +1,5 @@
+.PHONY: build-android-release
+
+build-android-release:
+	cd .. && flutter build appbundle --release
+	@echo "AAB at: build/app/outputs/bundle/release/app-release.aab"

--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -1,8 +1,19 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+// Load signing properties if the file exists (lives outside the repo at android/key.properties).
+val keystoreProperties = Properties()
+val keystorePropertiesFile = rootProject.file("key.properties")
+val hasKeystore = keystorePropertiesFile.exists()
+if (hasKeystore) {
+    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
 }
 
 android {
@@ -20,21 +31,29 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId = "com.jabsolutions.vamos"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        create("release") {
+            if (hasKeystore) {
+                storeFile = file(keystoreProperties["storeFile"] as String)
+                storePassword = keystoreProperties["storePassword"] as String
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            // Uses release keystore when key.properties is present; falls back to debug otherwise.
+            signingConfig = if (hasKeystore) signingConfigs.getByName("release") else signingConfigs.getByName("debug")
+            isMinifyEnabled = false // Flutter handles shrinking separately via --obfuscate / --split-debug-info
         }
     }
 }

--- a/app/android/key.properties.example
+++ b/app/android/key.properties.example
@@ -1,0 +1,4 @@
+storeFile=<path_to_keystore.jks>
+storePassword=<keystore_password>
+keyAlias=vamos
+keyPassword=<key_password>

--- a/app/ios/.gitignore
+++ b/app/ios/.gitignore
@@ -32,3 +32,8 @@ Runner/GeneratedPluginRegistrant.*
 !default.mode2v3
 !default.pbxuser
 !default.perspectivev3
+
+# Release build artifacts — never commit credentials or build output.
+ExportOptions.plist
+*.ipa
+*.xcarchive

--- a/app/ios/ExportOptions.plist.example
+++ b/app/ios/ExportOptions.plist.example
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store</string>
+    <key>teamID</key>
+    <string>YOUR_TEAM_ID</string>
+    <key>uploadBitcode</key>
+    <false/>
+    <key>compileBitcode</key>
+    <false/>
+    <key>destination</key>
+    <string>upload</string>
+</dict>
+</plist>

--- a/app/ios/release_build.sh
+++ b/app/ios/release_build.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+# Build iOS release archive and upload to TestFlight.
+#
+# Prerequisites:
+#   - Xcode with a valid Apple Developer account signed in
+#   - Provisioning profile for com.jabsolutions.vamos installed
+#   - ExportOptions.plist present in app/ios/ (copy from ExportOptions.plist.example, fill teamID)
+#
+# Usage:
+#   ./release_build.sh                          # uses ExportOptions.plist (default)
+#   ./release_build.sh MyExportOptions.plist    # uses a custom export options file
+
+EXPORT_OPTIONS="${1:-ExportOptions.plist}"
+
+# Resolve repo root relative to this script's location (app/ios/).
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+echo "Building Flutter iOS release (no-codesign)..."
+cd "$REPO_ROOT"
+flutter build ios --release --no-codesign
+
+echo "Archiving in Xcode..."
+xcodebuild -workspace ios/Runner.xcworkspace \
+           -scheme Runner \
+           -configuration Release \
+           -archivePath build/Runner.xcarchive \
+           archive
+
+echo "Exporting IPA..."
+xcodebuild -exportArchive \
+           -archivePath build/Runner.xcarchive \
+           -exportPath build/ios-release \
+           -exportOptionsPlist "ios/$EXPORT_OPTIONS"
+
+echo "IPA at: build/ios-release/vamos.ipa"
+echo "Upload to TestFlight via Xcode Organizer or run:"
+echo "  xcrun altool --upload-app -f build/ios-release/vamos.ipa -t ios --apiKey <KEY> --apiIssuer <ISSUER>"


### PR DESCRIPTION
## Summary

- **Android**: `build.gradle.kts` reads `key.properties` (gitignored) for release signing; falls back to debug if file absent. `Makefile` target `make build-android-release` produces the AAB. Template at `app/android/key.properties.example`.
- **iOS**: `app/ios/release_build.sh` (executable) runs `flutter build ios --no-codesign` → `xcodebuild archive` → `xcodebuild -exportArchive`. Template `ExportOptions.plist.example` for teamID. Signing delegated to Xcode/xcodebuild.
- **README.md**: `## Release builds` section with copy-paste steps for both platforms.

To produce the first TestFlight / Play internal build:
1. Android: create a keystore, fill `app/android/key.properties`, run `make build-android-release`
2. iOS: copy `ExportOptions.plist.example` → `ExportOptions.plist`, fill `teamID`, run `./app/ios/release_build.sh`

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)