### PR TITLE
fix: archive notifier false-positive + deploy Firestore rules

### DIFF
--- a/app/lib/features/trip_shell/presentation/trip_shell_screen.dart
+++ b/app/lib/features/trip_shell/presentation/trip_shell_screen.dart
@@ -66,9 +66,13 @@ class _TripShellScreenState extends ConsumerState<TripShellScreen>
     final isFacilitator = trip?.facilitatorId == currentUserId;
 
     // Listen for archive success → navigate away; error → SnackBar.
-    ref.listen<AsyncValue<void>>(archiveTripProvider, (prev, next) {
+    // The state type is bool? — null means idle (initial build), true means
+    // archived. This guards against the false-positive trigger that happens
+    // when AsyncNotifier<void>.build() completes and the listener fires.
+    ref.listen<AsyncValue<bool?>>(archiveTripProvider, (prev, next) {
       next.whenOrNull(
-        data: (_) {
+        data: (archived) {
+          if (archived != true) return; // null = idle, skip
           if (!context.mounted) return;
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text('Viaje archivado')),

--- a/app/lib/features/trips/application/archive_trip_notifier.dart
+++ b/app/lib/features/trips/application/archive_trip_notifier.dart
@@ -3,26 +3,35 @@ import 'package:vamos/data/repositories/firestore_trip_repository.dart';
 
 /// Mutation notifier for archiving a trip.
 ///
-/// The facilitator triggers [archive]; the UI listens to state changes
-/// to navigate away or show error feedback. Not safe for regular members
-/// to call — Firestore rules reject unauthorized writes.
-class ArchiveTripNotifier extends AutoDisposeAsyncNotifier<void> {
+/// State semantics:
+///   AsyncData(null)  → idle (initial; no action taken yet)
+///   AsyncLoading()   → archive in progress
+///   AsyncData(true)  → archive completed successfully
+///   AsyncError(...)  → archive failed
+///
+/// Using bool? instead of void prevents a false-positive listener trigger.
+/// An AutoDisposeAsyncNotifier<void> transitions AsyncLoading → AsyncData
+/// when build() completes, so any listener reacting to AsyncData would fire
+/// immediately on mount — before the user taps "Archivar". The null sentinel
+/// makes the idle state distinguishable from a successful archive.
+class ArchiveTripNotifier extends AutoDisposeAsyncNotifier<bool?> {
   @override
-  Future<void> build() async {}
+  Future<bool?> build() async => null; // null = idle
 
   /// Sets the trip status to "archived" in Firestore.
   ///
-  /// On success, [state] becomes [AsyncData]. On failure (e.g., network
+  /// On success, [state] becomes [AsyncData(true)]. On failure (e.g., network
   /// error or Firestore permission denied), [state] becomes [AsyncError].
   Future<void> archive(String tripId) async {
     state = const AsyncLoading();
     state = await AsyncValue.guard(() async {
       await ref.read(tripRepositoryProvider).archiveTrip(tripId);
+      return true;
     });
   }
 }
 
 final archiveTripProvider =
-    AsyncNotifierProvider.autoDispose<ArchiveTripNotifier, void>(
+    AsyncNotifierProvider.autoDispose<ArchiveTripNotifier, bool?>(
   ArchiveTripNotifier.new,
 );


### PR DESCRIPTION
## Bug 2 fix — "Viaje archivado" al entrar a un viaje

**Root cause**: `ArchiveTripNotifier extends AutoDisposeAsyncNotifier<void>`. When `TripShellScreen` mounts, the notifier's `build()` completes and transitions `AsyncLoading → AsyncData<void>`. The `ref.listen` callback fired on that transition and executed `showSnackBar('Viaje archivado') + context.go('/trips')` immediately — before the user tapped anything.

**Fix**: Changed state type to `bool?` (`null` = idle, `true` = archived). The listener now guards `if (archived != true) return` so the initial `AsyncData(null)` from `build()` is a no-op.

---

## Bug 1 — "Hubo un problema al crear el viaje"

**Root cause**: The Firestore security rules written in X-01 (PR #63) were committed to the repo but **never deployed** to the Firebase project. The live project still has the old rules that block the trip create batch write.

**Fix required** (manual — needs Firebase CLI credentials):
```bash
cd firebase
firebase deploy --only firestore:rules,firestore:indexes
```

Run this after merging this PR. The rules and indexes in `firebase/firestore.rules` and `firebase/firestore.indexes.json` are ready to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)